### PR TITLE
Move to C.calloc instead of C.malloc

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -2,6 +2,7 @@ package duckdb_go_bindings
 
 /*
 #include <duckdb.h>
+#include <stdlib.h>
 */
 import "C"
 
@@ -3553,7 +3554,7 @@ const (
 // The return value must be freed with Free.
 func allocLogicalTypes(types []LogicalType) unsafe.Pointer {
 	count := len(types)
-	s := (*[1 << 31]C.duckdb_logical_type)(C.malloc(C.size_t(count) * logicalTypeSize))
+	s := (*[1 << 31]C.duckdb_logical_type)(C.calloc(C.size_t(count), logicalTypeSize))
 	for i, t := range types {
 		// We only copy the pointers.
 		// The memory is allocated in the types slice.
@@ -3566,7 +3567,7 @@ func allocLogicalTypes(types []LogicalType) unsafe.Pointer {
 // The return value must be freed with Free.
 func allocValues(values []Value) unsafe.Pointer {
 	count := len(values)
-	s := (*[1 << 31]C.duckdb_value)(C.malloc(C.size_t(count) * valueSize))
+	s := (*[1 << 31]C.duckdb_value)(C.calloc(C.size_t(count), valueSize))
 	for i, val := range values {
 		// We only copy the pointers.
 		// The memory is allocated in the values slice.
@@ -3580,7 +3581,7 @@ func allocValues(values []Value) unsafe.Pointer {
 // The names must also be freed.
 func allocNames(names []string) unsafe.Pointer {
 	count := len(names)
-	s := (*[1 << 31]*C.char)(C.malloc(C.size_t(count) * charSize))
+	s := (*[1 << 31]*C.char)(C.calloc(C.size_t(count), charSize))
 	for i, name := range names {
 		(*s)[i] = C.CString(name)
 	}

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -51,3 +51,24 @@ func TestOpenSQLiteDB(t *testing.T) {
 	colType := ColumnType(&res, 0)
 	require.Equal(t, TypeBigInt, colType)
 }
+
+// TestCreateDataChunk ensures that we allocate C arrays correctly.
+func TestCreateDataChunk(t *testing.T) {
+	defer VerifyAllocationCounters()
+
+	tinyIntT := CreateLogicalType(TypeTinyInt)
+	defer DestroyLogicalType(&tinyIntT)
+
+	varcharT := CreateLogicalType(TypeVarchar)
+	defer DestroyLogicalType(&varcharT)
+
+	var types []LogicalType
+	types = append(types, tinyIntT, varcharT)
+
+	structT := CreateStructType(types, []string{"c1", "c2"})
+	defer DestroyLogicalType(&structT)
+
+	types = append(types, structT)
+	chunk := CreateDataChunk(types)
+	defer DestroyDataChunk(&chunk)
+}

--- a/darwin-amd64/bindings.go
+++ b/darwin-amd64/bindings.go
@@ -2,6 +2,7 @@ package duckdb_go_bindings
 
 /*
 #include <duckdb.h>
+#include <stdlib.h>
 */
 import "C"
 
@@ -3553,7 +3554,7 @@ const (
 // The return value must be freed with Free.
 func allocLogicalTypes(types []LogicalType) unsafe.Pointer {
 	count := len(types)
-	s := (*[1 << 31]C.duckdb_logical_type)(C.malloc(C.size_t(count) * logicalTypeSize))
+	s := (*[1 << 31]C.duckdb_logical_type)(C.calloc(C.size_t(count), logicalTypeSize))
 	for i, t := range types {
 		// We only copy the pointers.
 		// The memory is allocated in the types slice.
@@ -3566,7 +3567,7 @@ func allocLogicalTypes(types []LogicalType) unsafe.Pointer {
 // The return value must be freed with Free.
 func allocValues(values []Value) unsafe.Pointer {
 	count := len(values)
-	s := (*[1 << 31]C.duckdb_value)(C.malloc(C.size_t(count) * valueSize))
+	s := (*[1 << 31]C.duckdb_value)(C.calloc(C.size_t(count), valueSize))
 	for i, val := range values {
 		// We only copy the pointers.
 		// The memory is allocated in the values slice.
@@ -3580,7 +3581,7 @@ func allocValues(values []Value) unsafe.Pointer {
 // The names must also be freed.
 func allocNames(names []string) unsafe.Pointer {
 	count := len(names)
-	s := (*[1 << 31]*C.char)(C.malloc(C.size_t(count) * charSize))
+	s := (*[1 << 31]*C.char)(C.calloc(C.size_t(count), charSize))
 	for i, name := range names {
 		(*s)[i] = C.CString(name)
 	}

--- a/darwin-amd64/bindings_test.go
+++ b/darwin-amd64/bindings_test.go
@@ -51,3 +51,24 @@ func TestOpenSQLiteDB(t *testing.T) {
 	colType := ColumnType(&res, 0)
 	require.Equal(t, TypeBigInt, colType)
 }
+
+// TestCreateDataChunk ensures that we allocate C arrays correctly.
+func TestCreateDataChunk(t *testing.T) {
+	defer VerifyAllocationCounters()
+
+	tinyIntT := CreateLogicalType(TypeTinyInt)
+	defer DestroyLogicalType(&tinyIntT)
+
+	varcharT := CreateLogicalType(TypeVarchar)
+	defer DestroyLogicalType(&varcharT)
+
+	var types []LogicalType
+	types = append(types, tinyIntT, varcharT)
+
+	structT := CreateStructType(types, []string{"c1", "c2"})
+	defer DestroyLogicalType(&structT)
+
+	types = append(types, structT)
+	chunk := CreateDataChunk(types)
+	defer DestroyDataChunk(&chunk)
+}

--- a/darwin-arm64/bindings.go
+++ b/darwin-arm64/bindings.go
@@ -2,6 +2,7 @@ package duckdb_go_bindings
 
 /*
 #include <duckdb.h>
+#include <stdlib.h>
 */
 import "C"
 
@@ -3553,7 +3554,7 @@ const (
 // The return value must be freed with Free.
 func allocLogicalTypes(types []LogicalType) unsafe.Pointer {
 	count := len(types)
-	s := (*[1 << 31]C.duckdb_logical_type)(C.malloc(C.size_t(count) * logicalTypeSize))
+	s := (*[1 << 31]C.duckdb_logical_type)(C.calloc(C.size_t(count), logicalTypeSize))
 	for i, t := range types {
 		// We only copy the pointers.
 		// The memory is allocated in the types slice.
@@ -3566,7 +3567,7 @@ func allocLogicalTypes(types []LogicalType) unsafe.Pointer {
 // The return value must be freed with Free.
 func allocValues(values []Value) unsafe.Pointer {
 	count := len(values)
-	s := (*[1 << 31]C.duckdb_value)(C.malloc(C.size_t(count) * valueSize))
+	s := (*[1 << 31]C.duckdb_value)(C.calloc(C.size_t(count), valueSize))
 	for i, val := range values {
 		// We only copy the pointers.
 		// The memory is allocated in the values slice.
@@ -3580,7 +3581,7 @@ func allocValues(values []Value) unsafe.Pointer {
 // The names must also be freed.
 func allocNames(names []string) unsafe.Pointer {
 	count := len(names)
-	s := (*[1 << 31]*C.char)(C.malloc(C.size_t(count) * charSize))
+	s := (*[1 << 31]*C.char)(C.calloc(C.size_t(count), charSize))
 	for i, name := range names {
 		(*s)[i] = C.CString(name)
 	}

--- a/darwin-arm64/bindings_test.go
+++ b/darwin-arm64/bindings_test.go
@@ -51,3 +51,24 @@ func TestOpenSQLiteDB(t *testing.T) {
 	colType := ColumnType(&res, 0)
 	require.Equal(t, TypeBigInt, colType)
 }
+
+// TestCreateDataChunk ensures that we allocate C arrays correctly.
+func TestCreateDataChunk(t *testing.T) {
+	defer VerifyAllocationCounters()
+
+	tinyIntT := CreateLogicalType(TypeTinyInt)
+	defer DestroyLogicalType(&tinyIntT)
+
+	varcharT := CreateLogicalType(TypeVarchar)
+	defer DestroyLogicalType(&varcharT)
+
+	var types []LogicalType
+	types = append(types, tinyIntT, varcharT)
+
+	structT := CreateStructType(types, []string{"c1", "c2"})
+	defer DestroyLogicalType(&structT)
+
+	types = append(types, structT)
+	chunk := CreateDataChunk(types)
+	defer DestroyDataChunk(&chunk)
+}

--- a/linux-amd64/bindings.go
+++ b/linux-amd64/bindings.go
@@ -2,6 +2,7 @@ package duckdb_go_bindings
 
 /*
 #include <duckdb.h>
+#include <stdlib.h>
 */
 import "C"
 
@@ -3553,7 +3554,7 @@ const (
 // The return value must be freed with Free.
 func allocLogicalTypes(types []LogicalType) unsafe.Pointer {
 	count := len(types)
-	s := (*[1 << 31]C.duckdb_logical_type)(C.malloc(C.size_t(count) * logicalTypeSize))
+	s := (*[1 << 31]C.duckdb_logical_type)(C.calloc(C.size_t(count), logicalTypeSize))
 	for i, t := range types {
 		// We only copy the pointers.
 		// The memory is allocated in the types slice.
@@ -3566,7 +3567,7 @@ func allocLogicalTypes(types []LogicalType) unsafe.Pointer {
 // The return value must be freed with Free.
 func allocValues(values []Value) unsafe.Pointer {
 	count := len(values)
-	s := (*[1 << 31]C.duckdb_value)(C.malloc(C.size_t(count) * valueSize))
+	s := (*[1 << 31]C.duckdb_value)(C.calloc(C.size_t(count), valueSize))
 	for i, val := range values {
 		// We only copy the pointers.
 		// The memory is allocated in the values slice.
@@ -3580,7 +3581,7 @@ func allocValues(values []Value) unsafe.Pointer {
 // The names must also be freed.
 func allocNames(names []string) unsafe.Pointer {
 	count := len(names)
-	s := (*[1 << 31]*C.char)(C.malloc(C.size_t(count) * charSize))
+	s := (*[1 << 31]*C.char)(C.calloc(C.size_t(count), charSize))
 	for i, name := range names {
 		(*s)[i] = C.CString(name)
 	}

--- a/linux-amd64/bindings_test.go
+++ b/linux-amd64/bindings_test.go
@@ -51,3 +51,24 @@ func TestOpenSQLiteDB(t *testing.T) {
 	colType := ColumnType(&res, 0)
 	require.Equal(t, TypeBigInt, colType)
 }
+
+// TestCreateDataChunk ensures that we allocate C arrays correctly.
+func TestCreateDataChunk(t *testing.T) {
+	defer VerifyAllocationCounters()
+
+	tinyIntT := CreateLogicalType(TypeTinyInt)
+	defer DestroyLogicalType(&tinyIntT)
+
+	varcharT := CreateLogicalType(TypeVarchar)
+	defer DestroyLogicalType(&varcharT)
+
+	var types []LogicalType
+	types = append(types, tinyIntT, varcharT)
+
+	structT := CreateStructType(types, []string{"c1", "c2"})
+	defer DestroyLogicalType(&structT)
+
+	types = append(types, structT)
+	chunk := CreateDataChunk(types)
+	defer DestroyDataChunk(&chunk)
+}

--- a/linux-arm64/bindings.go
+++ b/linux-arm64/bindings.go
@@ -2,6 +2,7 @@ package duckdb_go_bindings
 
 /*
 #include <duckdb.h>
+#include <stdlib.h>
 */
 import "C"
 
@@ -3553,7 +3554,7 @@ const (
 // The return value must be freed with Free.
 func allocLogicalTypes(types []LogicalType) unsafe.Pointer {
 	count := len(types)
-	s := (*[1 << 31]C.duckdb_logical_type)(C.malloc(C.size_t(count) * logicalTypeSize))
+	s := (*[1 << 31]C.duckdb_logical_type)(C.calloc(C.size_t(count), logicalTypeSize))
 	for i, t := range types {
 		// We only copy the pointers.
 		// The memory is allocated in the types slice.
@@ -3566,7 +3567,7 @@ func allocLogicalTypes(types []LogicalType) unsafe.Pointer {
 // The return value must be freed with Free.
 func allocValues(values []Value) unsafe.Pointer {
 	count := len(values)
-	s := (*[1 << 31]C.duckdb_value)(C.malloc(C.size_t(count) * valueSize))
+	s := (*[1 << 31]C.duckdb_value)(C.calloc(C.size_t(count), valueSize))
 	for i, val := range values {
 		// We only copy the pointers.
 		// The memory is allocated in the values slice.
@@ -3580,7 +3581,7 @@ func allocValues(values []Value) unsafe.Pointer {
 // The names must also be freed.
 func allocNames(names []string) unsafe.Pointer {
 	count := len(names)
-	s := (*[1 << 31]*C.char)(C.malloc(C.size_t(count) * charSize))
+	s := (*[1 << 31]*C.char)(C.calloc(C.size_t(count), charSize))
 	for i, name := range names {
 		(*s)[i] = C.CString(name)
 	}

--- a/linux-arm64/bindings_test.go
+++ b/linux-arm64/bindings_test.go
@@ -51,3 +51,24 @@ func TestOpenSQLiteDB(t *testing.T) {
 	colType := ColumnType(&res, 0)
 	require.Equal(t, TypeBigInt, colType)
 }
+
+// TestCreateDataChunk ensures that we allocate C arrays correctly.
+func TestCreateDataChunk(t *testing.T) {
+	defer VerifyAllocationCounters()
+
+	tinyIntT := CreateLogicalType(TypeTinyInt)
+	defer DestroyLogicalType(&tinyIntT)
+
+	varcharT := CreateLogicalType(TypeVarchar)
+	defer DestroyLogicalType(&varcharT)
+
+	var types []LogicalType
+	types = append(types, tinyIntT, varcharT)
+
+	structT := CreateStructType(types, []string{"c1", "c2"})
+	defer DestroyLogicalType(&structT)
+
+	types = append(types, structT)
+	chunk := CreateDataChunk(types)
+	defer DestroyDataChunk(&chunk)
+}

--- a/windows-amd64/bindings.go
+++ b/windows-amd64/bindings.go
@@ -2,6 +2,7 @@ package duckdb_go_bindings
 
 /*
 #include <duckdb.h>
+#include <stdlib.h>
 */
 import "C"
 
@@ -3553,7 +3554,7 @@ const (
 // The return value must be freed with Free.
 func allocLogicalTypes(types []LogicalType) unsafe.Pointer {
 	count := len(types)
-	s := (*[1 << 31]C.duckdb_logical_type)(C.malloc(C.size_t(count) * logicalTypeSize))
+	s := (*[1 << 31]C.duckdb_logical_type)(C.calloc(C.size_t(count), logicalTypeSize))
 	for i, t := range types {
 		// We only copy the pointers.
 		// The memory is allocated in the types slice.
@@ -3566,7 +3567,7 @@ func allocLogicalTypes(types []LogicalType) unsafe.Pointer {
 // The return value must be freed with Free.
 func allocValues(values []Value) unsafe.Pointer {
 	count := len(values)
-	s := (*[1 << 31]C.duckdb_value)(C.malloc(C.size_t(count) * valueSize))
+	s := (*[1 << 31]C.duckdb_value)(C.calloc(C.size_t(count), valueSize))
 	for i, val := range values {
 		// We only copy the pointers.
 		// The memory is allocated in the values slice.
@@ -3580,7 +3581,7 @@ func allocValues(values []Value) unsafe.Pointer {
 // The names must also be freed.
 func allocNames(names []string) unsafe.Pointer {
 	count := len(names)
-	s := (*[1 << 31]*C.char)(C.malloc(C.size_t(count) * charSize))
+	s := (*[1 << 31]*C.char)(C.calloc(C.size_t(count), charSize))
 	for i, name := range names {
 		(*s)[i] = C.CString(name)
 	}

--- a/windows-amd64/bindings_test.go
+++ b/windows-amd64/bindings_test.go
@@ -51,3 +51,24 @@ func TestOpenSQLiteDB(t *testing.T) {
 	colType := ColumnType(&res, 0)
 	require.Equal(t, TypeBigInt, colType)
 }
+
+// TestCreateDataChunk ensures that we allocate C arrays correctly.
+func TestCreateDataChunk(t *testing.T) {
+	defer VerifyAllocationCounters()
+
+	tinyIntT := CreateLogicalType(TypeTinyInt)
+	defer DestroyLogicalType(&tinyIntT)
+
+	varcharT := CreateLogicalType(TypeVarchar)
+	defer DestroyLogicalType(&varcharT)
+
+	var types []LogicalType
+	types = append(types, tinyIntT, varcharT)
+
+	structT := CreateStructType(types, []string{"c1", "c2"})
+	defer DestroyLogicalType(&structT)
+
+	types = append(types, structT)
+	chunk := CreateDataChunk(types)
+	defer DestroyDataChunk(&chunk)
+}


### PR DESCRIPTION
Due to a [note on the official `cgo` implementation](https://pkg.go.dev/cmd/cgo), we've decided to move to `C.calloc` instead of `C.malloc`. We've seen cases where people run into garbage collector issues. Together with some other changes (follow-up PRs), hopefully, we can solve these GC issues.

Note that moving to `C.calloc` also requires a direct include of `#include <stdlib.h>`.

> Note: the current implementation has a bug. While Go code is permitted to write nil or a C pointer (but not a Go pointer) to C memory, the current implementation may sometimes cause a runtime error if the contents of the C memory appear to be a Go pointer. Therefore, avoid passing uninitialized C memory to Go code if the Go code is going to store pointer values in it. Zero out the memory in C before passing it to Go.