### PR TITLE
Add `-rdynamic` to `LDFLAGS` for Linux

### DIFF
--- a/linux-amd64/cgo_static.go
+++ b/linux-amd64/cgo_static.go
@@ -2,7 +2,7 @@ package duckdb_go_bindings
 
 /*
 #cgo CPPFLAGS: -DDUCKDB_STATIC_BUILD
-#cgo LDFLAGS:  -lduckdb_static -lautocomplete_extension -lcore_functions_extension -licu_extension -ljson_extension -lparquet_extension -ljemalloc_extension -ltpcds_extension -ltpch_extension -lduckdb_fastpforlib -lduckdb_fmt -lduckdb_fsst -lduckdb_hyperloglog -lduckdb_mbedtls -lduckdb_miniz -lduckdb_pg_query -lduckdb_re2 -lduckdb_skiplistlib -lduckdb_utf8proc -lduckdb_yyjson -lduckdb_zstd -lstdc++ -lm -ldl -L${SRCDIR}/
+#cgo LDFLAGS: -rdynamic -lduckdb_static -lautocomplete_extension -lcore_functions_extension -licu_extension -ljson_extension -lparquet_extension -ljemalloc_extension -ltpcds_extension -ltpch_extension -lduckdb_fastpforlib -lduckdb_fmt -lduckdb_fsst -lduckdb_hyperloglog -lduckdb_mbedtls -lduckdb_miniz -lduckdb_pg_query -lduckdb_re2 -lduckdb_skiplistlib -lduckdb_utf8proc -lduckdb_yyjson -lduckdb_zstd -lstdc++ -lm -ldl -L${SRCDIR}/
 #include <duckdb.h>
 */
 import "C"

--- a/linux-arm64/cgo_static.go
+++ b/linux-arm64/cgo_static.go
@@ -2,7 +2,7 @@ package duckdb_go_bindings
 
 /*
 #cgo CPPFLAGS: -DDUCKDB_STATIC_BUILD
-#cgo LDFLAGS: -lduckdb_static -lautocomplete_extension -lcore_functions_extension -licu_extension -ljson_extension -lparquet_extension -ljemalloc_extension -ltpcds_extension -ltpch_extension -lduckdb_fastpforlib -lduckdb_fmt -lduckdb_fsst -lduckdb_hyperloglog -lduckdb_mbedtls -lduckdb_miniz -lduckdb_pg_query -lduckdb_re2 -lduckdb_skiplistlib -lduckdb_utf8proc -lduckdb_yyjson -lduckdb_zstd -lstdc++ -lm -ldl -L${SRCDIR}/
+#cgo LDFLAGS: -rdynamic -lduckdb_static -lautocomplete_extension -lcore_functions_extension -licu_extension -ljson_extension -lparquet_extension -ljemalloc_extension -ltpcds_extension -ltpch_extension -lduckdb_fastpforlib -lduckdb_fmt -lduckdb_fsst -lduckdb_hyperloglog -lduckdb_mbedtls -lduckdb_miniz -lduckdb_pg_query -lduckdb_re2 -lduckdb_skiplistlib -lduckdb_utf8proc -lduckdb_yyjson -lduckdb_zstd -lstdc++ -lm -ldl -L${SRCDIR}/
 #include <duckdb.h>
 */
 import "C"


### PR DESCRIPTION
Enables meaningful stack traces for internal and fatal exceptions.

```
admin@ip-172-31-5-234:~/playground$ ./playground 
successfully threw exception
FATAL Error: hello

Stack Trace:

...
./playground(duckdb::PipelineExecutor::Execute(unsigned long)+0x12e) [0xf2afae]
./playground(duckdb::PipelineTask::ExecuteTask(duckdb::TaskExecutionMode)+0x15a) [0xf2b2fa]
./playground(duckdb::ExecutorTask::Execute(duckdb::TaskExecutionMode)+0xd1) [0xf21eb1]
./playground(duckdb::Executor::ExecuteTask(bool)+0x74) [0xf25144]
./playground(duckdb::ClientContext::ExecuteTaskInternal(duckdb::ClientContextLock&, duckdb::BaseQueryResult&, bool)+0x50) [0xed7d90]
./playground(duckdb::PendingQueryResult::ExecuteInternal(duckdb::ClientContextLock&)+0x3c) [0xed7fcc]
./playground(duckdb::PendingQueryResult::Execute()+0x34) [0xed8164]
./playground(duckdb_execute_pending+0x53) [0xe80e73]
./playground(_cgo_d974d5f59073_Cfunc_duckdb_execute_pending+0x1b) [0xe72f4b]
./playground() [0xd99644]
```

Instead of (before)
```
admin@ip-172-31-5-234:~/playground$ ./playground 
successfully threw exception
FATAL Error: hello

Stack Trace:

...
./playground() [0x906ac9]
./playground() [0x906c8b]
./playground() [0x90bfae]
./playground() [0x90c279]
./playground() [0x902eb1]
./playground() [0x90b020]
/lib/x86_64-linux-gnu/libstdc++.so.6(+0xe1224) [0x7f5aabce1224]
/lib/x86_64-linux-gnu/libc.so.6(+0x92b7b) [0x7f5aaba9cb7b]
/lib/x86_64-linux-gnu/libc.so.6(+0x1107b8) [0x7f5aabb1a7b8]
```