### PR TITLE
Move extension test to separate file

### DIFF
--- a/bindings_extensions_test.go
+++ b/bindings_extensions_test.go
@@ -10,7 +10,7 @@ import (
 func TestOpenSQLiteDB(t *testing.T) {
 	defer VerifyAllocationCounters()
 
-	dsn := "../test/pets.sqlite"
+	dsn := "test/pets.sqlite"
 
 	var config Config
 	defer DestroyConfig(&config)
@@ -44,4 +44,3 @@ func TestOpenSQLiteDB(t *testing.T) {
 	colType := ColumnType(&res, 0)
 	require.Equal(t, TypeBigInt, colType)
 }
-

--- a/bindings_extensions_test.go
+++ b/bindings_extensions_test.go
@@ -1,0 +1,47 @@
+package duckdb_go_bindings
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// TestOpenSQLiteDB ensures that extension auto install + load works,
+// as well as some basic C API functions.
+func TestOpenSQLiteDB(t *testing.T) {
+	defer VerifyAllocationCounters()
+
+	dsn := "../test/pets.sqlite"
+
+	var config Config
+	defer DestroyConfig(&config)
+	if CreateConfig(&config) == StateError {
+		t.Fail()
+	}
+
+	var db Database
+	defer Close(&db)
+
+	var errMsg string
+	if OpenExt(dsn, &db, config, &errMsg) == StateError {
+		require.Empty(t, errMsg)
+	}
+
+	var conn Connection
+	defer Disconnect(&conn)
+	if Connect(db, &conn) == StateError {
+		t.Fail()
+	}
+
+	var res Result
+	defer DestroyResult(&res)
+	if Query(conn, `SELECT COUNT(*) FROM pets`, &res) == StateError {
+		t.Fail()
+	}
+
+	colCount := int(ColumnCount(&res))
+	require.Equal(t, 1, colCount)
+
+	colType := ColumnType(&res, 0)
+	require.Equal(t, TypeBigInt, colType)
+}
+

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -12,46 +12,6 @@ func TestVectorSize(t *testing.T) {
 	require.Equal(t, IdxT(2048), VectorSize())
 }
 
-// TestOpenSQLiteDB ensures that extension auto install + load works,
-// as well as some basic C API functions.
-func TestOpenSQLiteDB(t *testing.T) {
-	defer VerifyAllocationCounters()
-
-	dsn := "test/pets.sqlite"
-
-	var config Config
-	defer DestroyConfig(&config)
-	if CreateConfig(&config) == StateError {
-		t.Fail()
-	}
-
-	var db Database
-	defer Close(&db)
-
-	var errMsg string
-	if OpenExt(dsn, &db, config, &errMsg) == StateError {
-		require.Empty(t, errMsg)
-	}
-
-	var conn Connection
-	defer Disconnect(&conn)
-	if Connect(db, &conn) == StateError {
-		t.Fail()
-	}
-
-	var res Result
-	defer DestroyResult(&res)
-	if Query(conn, `SELECT COUNT(*) FROM pets`, &res) == StateError {
-		t.Fail()
-	}
-
-	colCount := int(ColumnCount(&res))
-	require.Equal(t, 1, colCount)
-
-	colType := ColumnType(&res, 0)
-	require.Equal(t, TypeBigInt, colType)
-}
-
 // TestCreateDataChunk ensures that we allocate C arrays correctly.
 func TestCreateDataChunk(t *testing.T) {
 	defer VerifyAllocationCounters()

--- a/darwin-amd64/bindings_extensions_test.go
+++ b/darwin-amd64/bindings_extensions_test.go
@@ -1,0 +1,47 @@
+package duckdb_go_bindings
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// TestOpenSQLiteDB ensures that extension auto install + load works,
+// as well as some basic C API functions.
+func TestOpenSQLiteDB(t *testing.T) {
+	defer VerifyAllocationCounters()
+
+	dsn := "../test/pets.sqlite"
+
+	var config Config
+	defer DestroyConfig(&config)
+	if CreateConfig(&config) == StateError {
+		t.Fail()
+	}
+
+	var db Database
+	defer Close(&db)
+
+	var errMsg string
+	if OpenExt(dsn, &db, config, &errMsg) == StateError {
+		require.Empty(t, errMsg)
+	}
+
+	var conn Connection
+	defer Disconnect(&conn)
+	if Connect(db, &conn) == StateError {
+		t.Fail()
+	}
+
+	var res Result
+	defer DestroyResult(&res)
+	if Query(conn, `SELECT COUNT(*) FROM pets`, &res) == StateError {
+		t.Fail()
+	}
+
+	colCount := int(ColumnCount(&res))
+	require.Equal(t, 1, colCount)
+
+	colType := ColumnType(&res, 0)
+	require.Equal(t, TypeBigInt, colType)
+}
+

--- a/darwin-amd64/bindings_test.go
+++ b/darwin-amd64/bindings_test.go
@@ -12,46 +12,6 @@ func TestVectorSize(t *testing.T) {
 	require.Equal(t, IdxT(2048), VectorSize())
 }
 
-// TestOpenSQLiteDB ensures that extension auto install + load works,
-// as well as some basic C API functions.
-func TestOpenSQLiteDB(t *testing.T) {
-	defer VerifyAllocationCounters()
-
-	dsn := "../test/pets.sqlite"
-
-	var config Config
-	defer DestroyConfig(&config)
-	if CreateConfig(&config) == StateError {
-		t.Fail()
-	}
-
-	var db Database
-	defer Close(&db)
-
-	var errMsg string
-	if OpenExt(dsn, &db, config, &errMsg) == StateError {
-		require.Empty(t, errMsg)
-	}
-
-	var conn Connection
-	defer Disconnect(&conn)
-	if Connect(db, &conn) == StateError {
-		t.Fail()
-	}
-
-	var res Result
-	defer DestroyResult(&res)
-	if Query(conn, `SELECT COUNT(*) FROM pets`, &res) == StateError {
-		t.Fail()
-	}
-
-	colCount := int(ColumnCount(&res))
-	require.Equal(t, 1, colCount)
-
-	colType := ColumnType(&res, 0)
-	require.Equal(t, TypeBigInt, colType)
-}
-
 // TestCreateDataChunk ensures that we allocate C arrays correctly.
 func TestCreateDataChunk(t *testing.T) {
 	defer VerifyAllocationCounters()

--- a/darwin-arm64/bindings_extensions_test.go
+++ b/darwin-arm64/bindings_extensions_test.go
@@ -1,0 +1,47 @@
+package duckdb_go_bindings
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// TestOpenSQLiteDB ensures that extension auto install + load works,
+// as well as some basic C API functions.
+func TestOpenSQLiteDB(t *testing.T) {
+	defer VerifyAllocationCounters()
+
+	dsn := "../test/pets.sqlite"
+
+	var config Config
+	defer DestroyConfig(&config)
+	if CreateConfig(&config) == StateError {
+		t.Fail()
+	}
+
+	var db Database
+	defer Close(&db)
+
+	var errMsg string
+	if OpenExt(dsn, &db, config, &errMsg) == StateError {
+		require.Empty(t, errMsg)
+	}
+
+	var conn Connection
+	defer Disconnect(&conn)
+	if Connect(db, &conn) == StateError {
+		t.Fail()
+	}
+
+	var res Result
+	defer DestroyResult(&res)
+	if Query(conn, `SELECT COUNT(*) FROM pets`, &res) == StateError {
+		t.Fail()
+	}
+
+	colCount := int(ColumnCount(&res))
+	require.Equal(t, 1, colCount)
+
+	colType := ColumnType(&res, 0)
+	require.Equal(t, TypeBigInt, colType)
+}
+

--- a/darwin-arm64/bindings_test.go
+++ b/darwin-arm64/bindings_test.go
@@ -12,46 +12,6 @@ func TestVectorSize(t *testing.T) {
 	require.Equal(t, IdxT(2048), VectorSize())
 }
 
-// TestOpenSQLiteDB ensures that extension auto install + load works,
-// as well as some basic C API functions.
-func TestOpenSQLiteDB(t *testing.T) {
-	defer VerifyAllocationCounters()
-
-	dsn := "../test/pets.sqlite"
-
-	var config Config
-	defer DestroyConfig(&config)
-	if CreateConfig(&config) == StateError {
-		t.Fail()
-	}
-
-	var db Database
-	defer Close(&db)
-
-	var errMsg string
-	if OpenExt(dsn, &db, config, &errMsg) == StateError {
-		require.Empty(t, errMsg)
-	}
-
-	var conn Connection
-	defer Disconnect(&conn)
-	if Connect(db, &conn) == StateError {
-		t.Fail()
-	}
-
-	var res Result
-	defer DestroyResult(&res)
-	if Query(conn, `SELECT COUNT(*) FROM pets`, &res) == StateError {
-		t.Fail()
-	}
-
-	colCount := int(ColumnCount(&res))
-	require.Equal(t, 1, colCount)
-
-	colType := ColumnType(&res, 0)
-	require.Equal(t, TypeBigInt, colType)
-}
-
 // TestCreateDataChunk ensures that we allocate C arrays correctly.
 func TestCreateDataChunk(t *testing.T) {
 	defer VerifyAllocationCounters()

--- a/linux-amd64/bindings_extensions_test.go
+++ b/linux-amd64/bindings_extensions_test.go
@@ -1,0 +1,47 @@
+package duckdb_go_bindings
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// TestOpenSQLiteDB ensures that extension auto install + load works,
+// as well as some basic C API functions.
+func TestOpenSQLiteDB(t *testing.T) {
+	defer VerifyAllocationCounters()
+
+	dsn := "../test/pets.sqlite"
+
+	var config Config
+	defer DestroyConfig(&config)
+	if CreateConfig(&config) == StateError {
+		t.Fail()
+	}
+
+	var db Database
+	defer Close(&db)
+
+	var errMsg string
+	if OpenExt(dsn, &db, config, &errMsg) == StateError {
+		require.Empty(t, errMsg)
+	}
+
+	var conn Connection
+	defer Disconnect(&conn)
+	if Connect(db, &conn) == StateError {
+		t.Fail()
+	}
+
+	var res Result
+	defer DestroyResult(&res)
+	if Query(conn, `SELECT COUNT(*) FROM pets`, &res) == StateError {
+		t.Fail()
+	}
+
+	colCount := int(ColumnCount(&res))
+	require.Equal(t, 1, colCount)
+
+	colType := ColumnType(&res, 0)
+	require.Equal(t, TypeBigInt, colType)
+}
+

--- a/linux-amd64/bindings_test.go
+++ b/linux-amd64/bindings_test.go
@@ -12,46 +12,6 @@ func TestVectorSize(t *testing.T) {
 	require.Equal(t, IdxT(2048), VectorSize())
 }
 
-// TestOpenSQLiteDB ensures that extension auto install + load works,
-// as well as some basic C API functions.
-func TestOpenSQLiteDB(t *testing.T) {
-	defer VerifyAllocationCounters()
-
-	dsn := "../test/pets.sqlite"
-
-	var config Config
-	defer DestroyConfig(&config)
-	if CreateConfig(&config) == StateError {
-		t.Fail()
-	}
-
-	var db Database
-	defer Close(&db)
-
-	var errMsg string
-	if OpenExt(dsn, &db, config, &errMsg) == StateError {
-		require.Empty(t, errMsg)
-	}
-
-	var conn Connection
-	defer Disconnect(&conn)
-	if Connect(db, &conn) == StateError {
-		t.Fail()
-	}
-
-	var res Result
-	defer DestroyResult(&res)
-	if Query(conn, `SELECT COUNT(*) FROM pets`, &res) == StateError {
-		t.Fail()
-	}
-
-	colCount := int(ColumnCount(&res))
-	require.Equal(t, 1, colCount)
-
-	colType := ColumnType(&res, 0)
-	require.Equal(t, TypeBigInt, colType)
-}
-
 // TestCreateDataChunk ensures that we allocate C arrays correctly.
 func TestCreateDataChunk(t *testing.T) {
 	defer VerifyAllocationCounters()

--- a/linux-arm64/bindings_extensions_test.go
+++ b/linux-arm64/bindings_extensions_test.go
@@ -1,0 +1,47 @@
+package duckdb_go_bindings
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// TestOpenSQLiteDB ensures that extension auto install + load works,
+// as well as some basic C API functions.
+func TestOpenSQLiteDB(t *testing.T) {
+	defer VerifyAllocationCounters()
+
+	dsn := "../test/pets.sqlite"
+
+	var config Config
+	defer DestroyConfig(&config)
+	if CreateConfig(&config) == StateError {
+		t.Fail()
+	}
+
+	var db Database
+	defer Close(&db)
+
+	var errMsg string
+	if OpenExt(dsn, &db, config, &errMsg) == StateError {
+		require.Empty(t, errMsg)
+	}
+
+	var conn Connection
+	defer Disconnect(&conn)
+	if Connect(db, &conn) == StateError {
+		t.Fail()
+	}
+
+	var res Result
+	defer DestroyResult(&res)
+	if Query(conn, `SELECT COUNT(*) FROM pets`, &res) == StateError {
+		t.Fail()
+	}
+
+	colCount := int(ColumnCount(&res))
+	require.Equal(t, 1, colCount)
+
+	colType := ColumnType(&res, 0)
+	require.Equal(t, TypeBigInt, colType)
+}
+

--- a/linux-arm64/bindings_test.go
+++ b/linux-arm64/bindings_test.go
@@ -12,46 +12,6 @@ func TestVectorSize(t *testing.T) {
 	require.Equal(t, IdxT(2048), VectorSize())
 }
 
-// TestOpenSQLiteDB ensures that extension auto install + load works,
-// as well as some basic C API functions.
-func TestOpenSQLiteDB(t *testing.T) {
-	defer VerifyAllocationCounters()
-
-	dsn := "../test/pets.sqlite"
-
-	var config Config
-	defer DestroyConfig(&config)
-	if CreateConfig(&config) == StateError {
-		t.Fail()
-	}
-
-	var db Database
-	defer Close(&db)
-
-	var errMsg string
-	if OpenExt(dsn, &db, config, &errMsg) == StateError {
-		require.Empty(t, errMsg)
-	}
-
-	var conn Connection
-	defer Disconnect(&conn)
-	if Connect(db, &conn) == StateError {
-		t.Fail()
-	}
-
-	var res Result
-	defer DestroyResult(&res)
-	if Query(conn, `SELECT COUNT(*) FROM pets`, &res) == StateError {
-		t.Fail()
-	}
-
-	colCount := int(ColumnCount(&res))
-	require.Equal(t, 1, colCount)
-
-	colType := ColumnType(&res, 0)
-	require.Equal(t, TypeBigInt, colType)
-}
-
 // TestCreateDataChunk ensures that we allocate C arrays correctly.
 func TestCreateDataChunk(t *testing.T) {
 	defer VerifyAllocationCounters()

--- a/windows-amd64/bindings_extensions_test.go
+++ b/windows-amd64/bindings_extensions_test.go
@@ -1,0 +1,47 @@
+package duckdb_go_bindings
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// TestOpenSQLiteDB ensures that extension auto install + load works,
+// as well as some basic C API functions.
+func TestOpenSQLiteDB(t *testing.T) {
+	defer VerifyAllocationCounters()
+
+	dsn := "../test/pets.sqlite"
+
+	var config Config
+	defer DestroyConfig(&config)
+	if CreateConfig(&config) == StateError {
+		t.Fail()
+	}
+
+	var db Database
+	defer Close(&db)
+
+	var errMsg string
+	if OpenExt(dsn, &db, config, &errMsg) == StateError {
+		require.Empty(t, errMsg)
+	}
+
+	var conn Connection
+	defer Disconnect(&conn)
+	if Connect(db, &conn) == StateError {
+		t.Fail()
+	}
+
+	var res Result
+	defer DestroyResult(&res)
+	if Query(conn, `SELECT COUNT(*) FROM pets`, &res) == StateError {
+		t.Fail()
+	}
+
+	colCount := int(ColumnCount(&res))
+	require.Equal(t, 1, colCount)
+
+	colType := ColumnType(&res, 0)
+	require.Equal(t, TypeBigInt, colType)
+}
+

--- a/windows-amd64/bindings_test.go
+++ b/windows-amd64/bindings_test.go
@@ -12,46 +12,6 @@ func TestVectorSize(t *testing.T) {
 	require.Equal(t, IdxT(2048), VectorSize())
 }
 
-// TestOpenSQLiteDB ensures that extension auto install + load works,
-// as well as some basic C API functions.
-func TestOpenSQLiteDB(t *testing.T) {
-	defer VerifyAllocationCounters()
-
-	dsn := "../test/pets.sqlite"
-
-	var config Config
-	defer DestroyConfig(&config)
-	if CreateConfig(&config) == StateError {
-		t.Fail()
-	}
-
-	var db Database
-	defer Close(&db)
-
-	var errMsg string
-	if OpenExt(dsn, &db, config, &errMsg) == StateError {
-		require.Empty(t, errMsg)
-	}
-
-	var conn Connection
-	defer Disconnect(&conn)
-	if Connect(db, &conn) == StateError {
-		t.Fail()
-	}
-
-	var res Result
-	defer DestroyResult(&res)
-	if Query(conn, `SELECT COUNT(*) FROM pets`, &res) == StateError {
-		t.Fail()
-	}
-
-	colCount := int(ColumnCount(&res))
-	require.Equal(t, 1, colCount)
-
-	colType := ColumnType(&res, 0)
-	require.Equal(t, TypeBigInt, colType)
-}
-
 // TestCreateDataChunk ensures that we allocate C arrays correctly.
 func TestCreateDataChunk(t *testing.T) {
 	defer VerifyAllocationCounters()


### PR DESCRIPTION
The extension test is expected to break for non-official duckdb releases missing a matching extension build. Moving it to a separate file makes some automated scripts (to publish a custom build) easier, and also makes that distinction clearer.