### PR TITLE
Change DataChunkFromArrow to use an existing data chunk instead of creating a new one

### DIFF
--- a/bindings_arrow.go
+++ b/bindings_arrow.go
@@ -155,6 +155,7 @@ func SchemaFromArrow(conn Connection, schema *arrow.Schema) (ArrowConvertedSchem
 // The returned DataChunk must be destroyed with DestroyDataChunk.
 // The returned ErrorData must be checked for errors and destroyed with DestroyErrorData.
 func DataChunkFromArrow(conn Connection, rec arrow.RecordBatch, schema ArrowConvertedSchema, chunk DataChunk) ErrorData {
+	// Export Arrow RecordBatch to C ArrowArray
 	arr := C.calloc(1, C.sizeof_struct_ArrowArray)
 	defer func() {
 		cdata.ReleaseCArrowArray((*cdata.CArrowArray)(arr))
@@ -176,7 +177,8 @@ func DataChunkFromArrow(conn Connection, rec arrow.RecordBatch, schema ArrowConv
 	if debugMode {
 		incrAllocCount("chunk")
 	}
-	// TODO: remove once duckdb_data_chunk_from_arrow sets the size correctly
+
+	// TODO: There is some bug here, so we have to set this manually: https://github.com/duckdb/duckdb/issues/20195
 	DataChunkSetSize(chunk, IdxT(rec.NumRows()))
 	return errData
 }

--- a/bindings_arrow_test.go
+++ b/bindings_arrow_test.go
@@ -4,8 +4,10 @@ package duckdb_go_bindings
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -110,5 +112,26 @@ func TestArrow(t *testing.T) {
 	require.Equal(t, colCount, cc)
 
 	rc := DataChunkGetSize(dataChunk)
-	require.Equal(t, IdxT(rec.NumRows()), rc)
+	assert.Equal(t, IdxT(3), rc)
+
+	// check chunk values
+	vecInt := DataChunkGetVector(chunk, IdxT(0))
+	vecStr := DataChunkGetVector(chunk, IdxT(1))
+	for rowIdx := range 3 {
+		intVal := getPrimitive[int32](vecInt, IdxT(rowIdx))
+		assert.Equal(t, int32(rowIdx+1), intVal)
+
+		strT := getPrimitive[StringT](vecStr, IdxT(rowIdx))
+		strVal := StringTData(&strT)
+		assert.Equal(t, []string{"foo", "bar", ""}[rowIdx], strVal)
+	}
+}
+
+func getPrimitive[T any](vec Vector, rowIdx IdxT) T {
+	dataPtr := VectorGetData(vec)
+	var zero T
+	elementSize := unsafe.Sizeof(zero)
+	offset := uintptr(rowIdx) * elementSize
+	ptr := unsafe.Add(dataPtr, offset)
+	return *(*T)(ptr)
 }

--- a/darwin-amd64/bindings_arrow.go
+++ b/darwin-amd64/bindings_arrow.go
@@ -155,6 +155,7 @@ func SchemaFromArrow(conn Connection, schema *arrow.Schema) (ArrowConvertedSchem
 // The returned DataChunk must be destroyed with DestroyDataChunk.
 // The returned ErrorData must be checked for errors and destroyed with DestroyErrorData.
 func DataChunkFromArrow(conn Connection, rec arrow.RecordBatch, schema ArrowConvertedSchema, chunk DataChunk) ErrorData {
+	// Export Arrow RecordBatch to C ArrowArray
 	arr := C.calloc(1, C.sizeof_struct_ArrowArray)
 	defer func() {
 		cdata.ReleaseCArrowArray((*cdata.CArrowArray)(arr))
@@ -176,7 +177,8 @@ func DataChunkFromArrow(conn Connection, rec arrow.RecordBatch, schema ArrowConv
 	if debugMode {
 		incrAllocCount("chunk")
 	}
-	// TODO: remove once duckdb_data_chunk_from_arrow sets the size correctly
+
+	// TODO: There is some bug here, so we have to set this manually: https://github.com/duckdb/duckdb/issues/20195
 	DataChunkSetSize(chunk, IdxT(rec.NumRows()))
 	return errData
 }

--- a/darwin-amd64/bindings_arrow_test.go
+++ b/darwin-amd64/bindings_arrow_test.go
@@ -4,8 +4,10 @@ package duckdb_go_bindings
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -110,5 +112,26 @@ func TestArrow(t *testing.T) {
 	require.Equal(t, colCount, cc)
 
 	rc := DataChunkGetSize(dataChunk)
-	require.Equal(t, IdxT(rec.NumRows()), rc)
+	assert.Equal(t, IdxT(3), rc)
+
+	// check chunk values
+	vecInt := DataChunkGetVector(chunk, IdxT(0))
+	vecStr := DataChunkGetVector(chunk, IdxT(1))
+	for rowIdx := range 3 {
+		intVal := getPrimitive[int32](vecInt, IdxT(rowIdx))
+		assert.Equal(t, int32(rowIdx+1), intVal)
+
+		strT := getPrimitive[StringT](vecStr, IdxT(rowIdx))
+		strVal := StringTData(&strT)
+		assert.Equal(t, []string{"foo", "bar", ""}[rowIdx], strVal)
+	}
+}
+
+func getPrimitive[T any](vec Vector, rowIdx IdxT) T {
+	dataPtr := VectorGetData(vec)
+	var zero T
+	elementSize := unsafe.Sizeof(zero)
+	offset := uintptr(rowIdx) * elementSize
+	ptr := unsafe.Add(dataPtr, offset)
+	return *(*T)(ptr)
 }

--- a/darwin-arm64/bindings_arrow.go
+++ b/darwin-arm64/bindings_arrow.go
@@ -155,6 +155,7 @@ func SchemaFromArrow(conn Connection, schema *arrow.Schema) (ArrowConvertedSchem
 // The returned DataChunk must be destroyed with DestroyDataChunk.
 // The returned ErrorData must be checked for errors and destroyed with DestroyErrorData.
 func DataChunkFromArrow(conn Connection, rec arrow.RecordBatch, schema ArrowConvertedSchema, chunk DataChunk) ErrorData {
+	// Export Arrow RecordBatch to C ArrowArray
 	arr := C.calloc(1, C.sizeof_struct_ArrowArray)
 	defer func() {
 		cdata.ReleaseCArrowArray((*cdata.CArrowArray)(arr))
@@ -176,7 +177,8 @@ func DataChunkFromArrow(conn Connection, rec arrow.RecordBatch, schema ArrowConv
 	if debugMode {
 		incrAllocCount("chunk")
 	}
-	// TODO: remove once duckdb_data_chunk_from_arrow sets the size correctly
+
+	// TODO: There is some bug here, so we have to set this manually: https://github.com/duckdb/duckdb/issues/20195
 	DataChunkSetSize(chunk, IdxT(rec.NumRows()))
 	return errData
 }

--- a/darwin-arm64/bindings_arrow_test.go
+++ b/darwin-arm64/bindings_arrow_test.go
@@ -4,8 +4,10 @@ package duckdb_go_bindings
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -110,5 +112,26 @@ func TestArrow(t *testing.T) {
 	require.Equal(t, colCount, cc)
 
 	rc := DataChunkGetSize(dataChunk)
-	require.Equal(t, IdxT(rec.NumRows()), rc)
+	assert.Equal(t, IdxT(3), rc)
+
+	// check chunk values
+	vecInt := DataChunkGetVector(chunk, IdxT(0))
+	vecStr := DataChunkGetVector(chunk, IdxT(1))
+	for rowIdx := range 3 {
+		intVal := getPrimitive[int32](vecInt, IdxT(rowIdx))
+		assert.Equal(t, int32(rowIdx+1), intVal)
+
+		strT := getPrimitive[StringT](vecStr, IdxT(rowIdx))
+		strVal := StringTData(&strT)
+		assert.Equal(t, []string{"foo", "bar", ""}[rowIdx], strVal)
+	}
+}
+
+func getPrimitive[T any](vec Vector, rowIdx IdxT) T {
+	dataPtr := VectorGetData(vec)
+	var zero T
+	elementSize := unsafe.Sizeof(zero)
+	offset := uintptr(rowIdx) * elementSize
+	ptr := unsafe.Add(dataPtr, offset)
+	return *(*T)(ptr)
 }

--- a/linux-amd64/bindings_arrow.go
+++ b/linux-amd64/bindings_arrow.go
@@ -155,6 +155,7 @@ func SchemaFromArrow(conn Connection, schema *arrow.Schema) (ArrowConvertedSchem
 // The returned DataChunk must be destroyed with DestroyDataChunk.
 // The returned ErrorData must be checked for errors and destroyed with DestroyErrorData.
 func DataChunkFromArrow(conn Connection, rec arrow.RecordBatch, schema ArrowConvertedSchema, chunk DataChunk) ErrorData {
+	// Export Arrow RecordBatch to C ArrowArray
 	arr := C.calloc(1, C.sizeof_struct_ArrowArray)
 	defer func() {
 		cdata.ReleaseCArrowArray((*cdata.CArrowArray)(arr))
@@ -176,7 +177,8 @@ func DataChunkFromArrow(conn Connection, rec arrow.RecordBatch, schema ArrowConv
 	if debugMode {
 		incrAllocCount("chunk")
 	}
-	// TODO: remove once duckdb_data_chunk_from_arrow sets the size correctly
+
+	// TODO: There is some bug here, so we have to set this manually: https://github.com/duckdb/duckdb/issues/20195
 	DataChunkSetSize(chunk, IdxT(rec.NumRows()))
 	return errData
 }

--- a/linux-amd64/bindings_arrow_test.go
+++ b/linux-amd64/bindings_arrow_test.go
@@ -4,8 +4,10 @@ package duckdb_go_bindings
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -110,5 +112,26 @@ func TestArrow(t *testing.T) {
 	require.Equal(t, colCount, cc)
 
 	rc := DataChunkGetSize(dataChunk)
-	require.Equal(t, IdxT(rec.NumRows()), rc)
+	assert.Equal(t, IdxT(3), rc)
+
+	// check chunk values
+	vecInt := DataChunkGetVector(chunk, IdxT(0))
+	vecStr := DataChunkGetVector(chunk, IdxT(1))
+	for rowIdx := range 3 {
+		intVal := getPrimitive[int32](vecInt, IdxT(rowIdx))
+		assert.Equal(t, int32(rowIdx+1), intVal)
+
+		strT := getPrimitive[StringT](vecStr, IdxT(rowIdx))
+		strVal := StringTData(&strT)
+		assert.Equal(t, []string{"foo", "bar", ""}[rowIdx], strVal)
+	}
+}
+
+func getPrimitive[T any](vec Vector, rowIdx IdxT) T {
+	dataPtr := VectorGetData(vec)
+	var zero T
+	elementSize := unsafe.Sizeof(zero)
+	offset := uintptr(rowIdx) * elementSize
+	ptr := unsafe.Add(dataPtr, offset)
+	return *(*T)(ptr)
 }

--- a/linux-arm64/bindings_arrow.go
+++ b/linux-arm64/bindings_arrow.go
@@ -155,6 +155,7 @@ func SchemaFromArrow(conn Connection, schema *arrow.Schema) (ArrowConvertedSchem
 // The returned DataChunk must be destroyed with DestroyDataChunk.
 // The returned ErrorData must be checked for errors and destroyed with DestroyErrorData.
 func DataChunkFromArrow(conn Connection, rec arrow.RecordBatch, schema ArrowConvertedSchema, chunk DataChunk) ErrorData {
+	// Export Arrow RecordBatch to C ArrowArray
 	arr := C.calloc(1, C.sizeof_struct_ArrowArray)
 	defer func() {
 		cdata.ReleaseCArrowArray((*cdata.CArrowArray)(arr))
@@ -176,7 +177,8 @@ func DataChunkFromArrow(conn Connection, rec arrow.RecordBatch, schema ArrowConv
 	if debugMode {
 		incrAllocCount("chunk")
 	}
-	// TODO: remove once duckdb_data_chunk_from_arrow sets the size correctly
+
+	// TODO: There is some bug here, so we have to set this manually: https://github.com/duckdb/duckdb/issues/20195
 	DataChunkSetSize(chunk, IdxT(rec.NumRows()))
 	return errData
 }

--- a/linux-arm64/bindings_arrow_test.go
+++ b/linux-arm64/bindings_arrow_test.go
@@ -4,8 +4,10 @@ package duckdb_go_bindings
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -110,5 +112,26 @@ func TestArrow(t *testing.T) {
 	require.Equal(t, colCount, cc)
 
 	rc := DataChunkGetSize(dataChunk)
-	require.Equal(t, IdxT(rec.NumRows()), rc)
+	assert.Equal(t, IdxT(3), rc)
+
+	// check chunk values
+	vecInt := DataChunkGetVector(chunk, IdxT(0))
+	vecStr := DataChunkGetVector(chunk, IdxT(1))
+	for rowIdx := range 3 {
+		intVal := getPrimitive[int32](vecInt, IdxT(rowIdx))
+		assert.Equal(t, int32(rowIdx+1), intVal)
+
+		strT := getPrimitive[StringT](vecStr, IdxT(rowIdx))
+		strVal := StringTData(&strT)
+		assert.Equal(t, []string{"foo", "bar", ""}[rowIdx], strVal)
+	}
+}
+
+func getPrimitive[T any](vec Vector, rowIdx IdxT) T {
+	dataPtr := VectorGetData(vec)
+	var zero T
+	elementSize := unsafe.Sizeof(zero)
+	offset := uintptr(rowIdx) * elementSize
+	ptr := unsafe.Add(dataPtr, offset)
+	return *(*T)(ptr)
 }

--- a/windows-amd64/bindings_arrow.go
+++ b/windows-amd64/bindings_arrow.go
@@ -155,6 +155,7 @@ func SchemaFromArrow(conn Connection, schema *arrow.Schema) (ArrowConvertedSchem
 // The returned DataChunk must be destroyed with DestroyDataChunk.
 // The returned ErrorData must be checked for errors and destroyed with DestroyErrorData.
 func DataChunkFromArrow(conn Connection, rec arrow.RecordBatch, schema ArrowConvertedSchema, chunk DataChunk) ErrorData {
+	// Export Arrow RecordBatch to C ArrowArray
 	arr := C.calloc(1, C.sizeof_struct_ArrowArray)
 	defer func() {
 		cdata.ReleaseCArrowArray((*cdata.CArrowArray)(arr))
@@ -176,7 +177,8 @@ func DataChunkFromArrow(conn Connection, rec arrow.RecordBatch, schema ArrowConv
 	if debugMode {
 		incrAllocCount("chunk")
 	}
-	// TODO: remove once duckdb_data_chunk_from_arrow sets the size correctly
+
+	// TODO: There is some bug here, so we have to set this manually: https://github.com/duckdb/duckdb/issues/20195
 	DataChunkSetSize(chunk, IdxT(rec.NumRows()))
 	return errData
 }

--- a/windows-amd64/bindings_arrow_test.go
+++ b/windows-amd64/bindings_arrow_test.go
@@ -4,8 +4,10 @@ package duckdb_go_bindings
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -110,5 +112,26 @@ func TestArrow(t *testing.T) {
 	require.Equal(t, colCount, cc)
 
 	rc := DataChunkGetSize(dataChunk)
-	require.Equal(t, IdxT(rec.NumRows()), rc)
+	assert.Equal(t, IdxT(3), rc)
+
+	// check chunk values
+	vecInt := DataChunkGetVector(chunk, IdxT(0))
+	vecStr := DataChunkGetVector(chunk, IdxT(1))
+	for rowIdx := range 3 {
+		intVal := getPrimitive[int32](vecInt, IdxT(rowIdx))
+		assert.Equal(t, int32(rowIdx+1), intVal)
+
+		strT := getPrimitive[StringT](vecStr, IdxT(rowIdx))
+		strVal := StringTData(&strT)
+		assert.Equal(t, []string{"foo", "bar", ""}[rowIdx], strVal)
+	}
+}
+
+func getPrimitive[T any](vec Vector, rowIdx IdxT) T {
+	dataPtr := VectorGetData(vec)
+	var zero T
+	elementSize := unsafe.Sizeof(zero)
+	offset := uintptr(rowIdx) * elementSize
+	ptr := unsafe.Add(dataPtr, offset)
+	return *(*T)(ptr)
 }


### PR DESCRIPTION
This would allow a table UDF to use an arrow to directly fill a data chunk in the FillChunk callback.