### PR TITLE
Add empty include.go to make sure vendoring works

### DIFF
--- a/cgo.go
+++ b/cgo.go
@@ -8,3 +8,5 @@ package duckdb_go_bindings
 #include <duckdb.h>
 */
 import "C"
+
+import _ "github.com/duckdb/duckdb-go-bindings/include"

--- a/include/include.go
+++ b/include/include.go
@@ -1,0 +1,3 @@
+// Package include exists to ensure this directory is vendored by Go.
+// It contains the DuckDB C header files needed for CGO compilation.
+package include


### PR DESCRIPTION
In 89b18b4a5 duckdb.h was moved from the repository root, to the include directory. This had the side effect of breaking `go mod vendor`. The reason is that the include directory is not considered a go module, so it won't be vendored by `go mod vendor` resulting in "duckdb.h file not found" errors. This adds an empty go file in the include directory and starts using that package so that `go mod vendor` understands that the header files in that directory should be vendored.

Another way to fix it would be to move the headers back to the repository root.

The easiest way to reproduce the issue is to go to the duckdb-go repository and run:
```bash
go mod vendor
go build
```