### PR TITLE
Add missing static lib to prebuilt.go

### DIFF
--- a/lib/darwin-amd64/prebuilt.go
+++ b/lib/darwin-amd64/prebuilt.go
@@ -4,8 +4,7 @@ package duckdb_go_bindings_platform
 
 /*
 #cgo CPPFLAGS: -I${SRCDIR} -DDUCKDB_STATIC_BUILD
-#cgo LDFLAGS: -lduckdb_static -lautocomplete_extension -lcore_functions_extension -licu_extension -ljson_extension -lparquet_extension -ltpcds_extension -ltpch_extension -lduckdb_fastpforlib -lduckdb_fmt -lduckdb_fsst -lduckdb_hyperloglog -lduckdb_mbedtls -lduckdb_miniz -lduckdb_pg_query -lduckdb_re2 -lduckdb_skiplistlib -lduckdb_utf8proc -lduckdb_yyjson -lduckdb_zstd -lc++ -L${SRCDIR}
+#cgo LDFLAGS: -lduckdb_static -lautocomplete_extension -lcore_functions_extension -licu_extension -ljson_extension -lparquet_extension -ltpcds_extension -ltpch_extension -lduckdb_fastpforlib -lduckdb_fmt -lduckdb_fsst -lduckdb_hyperloglog -lduckdb_mbedtls -lduckdb_miniz -lduckdb_pg_query -lduckdb_re2 -lduckdb_skiplistlib -lduckdb_utf8proc -lduckdb_yyjson -lduckdb_zstd -llibdummy_static_extension_loader -lc++ -L${SRCDIR}
 #include <duckdb.h>
 */
 import "C"
-

--- a/lib/darwin-arm64/prebuilt.go
+++ b/lib/darwin-arm64/prebuilt.go
@@ -4,8 +4,7 @@ package duckdb_go_bindings_platform
 
 /*
 #cgo CPPFLAGS: -I${SRCDIR} -DDUCKDB_STATIC_BUILD
-#cgo LDFLAGS: -lduckdb_static -lautocomplete_extension -lcore_functions_extension -licu_extension -ljson_extension -lparquet_extension -ltpcds_extension -ltpch_extension -lduckdb_fastpforlib -lduckdb_fmt -lduckdb_fsst -lduckdb_hyperloglog -lduckdb_mbedtls -lduckdb_miniz -lduckdb_pg_query -lduckdb_re2 -lduckdb_skiplistlib -lduckdb_utf8proc -lduckdb_yyjson -lduckdb_zstd -lc++ -L${SRCDIR}
+#cgo LDFLAGS: -lduckdb_static -lautocomplete_extension -lcore_functions_extension -licu_extension -ljson_extension -lparquet_extension -ltpcds_extension -ltpch_extension -lduckdb_fastpforlib -lduckdb_fmt -lduckdb_fsst -lduckdb_hyperloglog -lduckdb_mbedtls -lduckdb_miniz -lduckdb_pg_query -lduckdb_re2 -lduckdb_skiplistlib -lduckdb_utf8proc -lduckdb_yyjson -lduckdb_zstd -llibdummy_static_extension_loader -lc++ -L${SRCDIR}
 #include <duckdb.h>
 */
 import "C"
-

--- a/lib/linux-amd64/prebuilt.go
+++ b/lib/linux-amd64/prebuilt.go
@@ -4,8 +4,7 @@ package duckdb_go_bindings_platform
 
 /*
 #cgo CPPFLAGS: -I${SRCDIR} -DDUCKDB_STATIC_BUILD
-#cgo LDFLAGS: -rdynamic -lduckdb_static -lautocomplete_extension -lcore_functions_extension -licu_extension -ljson_extension -lparquet_extension -ljemalloc_extension -ltpcds_extension -ltpch_extension -lduckdb_fastpforlib -lduckdb_fmt -lduckdb_fsst -lduckdb_hyperloglog -lduckdb_mbedtls -lduckdb_miniz -lduckdb_pg_query -lduckdb_re2 -lduckdb_skiplistlib -lduckdb_utf8proc -lduckdb_yyjson -lduckdb_zstd -lstdc++ -lm -ldl -L${SRCDIR}
+#cgo LDFLAGS: -rdynamic -lduckdb_static -lautocomplete_extension -lcore_functions_extension -licu_extension -ljson_extension -lparquet_extension -ljemalloc_extension -ltpcds_extension -ltpch_extension -lduckdb_fastpforlib -lduckdb_fmt -lduckdb_fsst -lduckdb_hyperloglog -lduckdb_mbedtls -lduckdb_miniz -lduckdb_pg_query -lduckdb_re2 -lduckdb_skiplistlib -lduckdb_utf8proc -lduckdb_yyjson -lduckdb_zstd -llibdummy_static_extension_loader -lstdc++ -lm -ldl -L${SRCDIR}
 #include <duckdb.h>
 */
 import "C"
-

--- a/lib/linux-arm64/prebuilt.go
+++ b/lib/linux-arm64/prebuilt.go
@@ -4,8 +4,7 @@ package duckdb_go_bindings_platform
 
 /*
 #cgo CPPFLAGS: -I${SRCDIR} -DDUCKDB_STATIC_BUILD
-#cgo LDFLAGS: -rdynamic -lduckdb_static -lautocomplete_extension -lcore_functions_extension -licu_extension -ljson_extension -lparquet_extension -ljemalloc_extension -ltpcds_extension -ltpch_extension -lduckdb_fastpforlib -lduckdb_fmt -lduckdb_fsst -lduckdb_hyperloglog -lduckdb_mbedtls -lduckdb_miniz -lduckdb_pg_query -lduckdb_re2 -lduckdb_skiplistlib -lduckdb_utf8proc -lduckdb_yyjson -lduckdb_zstd -lstdc++ -lm -ldl -L${SRCDIR}
+#cgo LDFLAGS: -rdynamic -lduckdb_static -lautocomplete_extension -lcore_functions_extension -licu_extension -ljson_extension -lparquet_extension -ljemalloc_extension -ltpcds_extension -ltpch_extension -lduckdb_fastpforlib -lduckdb_fmt -lduckdb_fsst -lduckdb_hyperloglog -lduckdb_mbedtls -lduckdb_miniz -lduckdb_pg_query -lduckdb_re2 -lduckdb_skiplistlib -lduckdb_utf8proc -lduckdb_yyjson -lduckdb_zstd -llibdummy_static_extension_loader -lstdc++ -lm -ldl -L${SRCDIR}
 #include <duckdb.h>
 */
 import "C"
-

--- a/lib/windows-amd64/prebuilt.go
+++ b/lib/windows-amd64/prebuilt.go
@@ -4,8 +4,7 @@ package duckdb_go_bindings_platform
 
 /*
 #cgo CPPFLAGS: -I${SRCDIR} -DDUCKDB_STATIC_BUILD
-#cgo LDFLAGS: -lduckdb_static -lautocomplete_extension -lcore_functions_extension -licu_extension -ljson_extension -lparquet_extension -ltpcds_extension -ltpch_extension -lduckdb_fastpforlib -lduckdb_fmt -lduckdb_fsst -lduckdb_hyperloglog -lduckdb_mbedtls -lduckdb_miniz -lduckdb_pg_query -lduckdb_re2 -lduckdb_skiplistlib -lduckdb_utf8proc -lduckdb_yyjson -lduckdb_zstd -lws2_32 -lwsock32 -lrstrtmgr -lstdc++ -lm --static -L${SRCDIR}
+#cgo LDFLAGS: -lduckdb_static -lautocomplete_extension -lcore_functions_extension -licu_extension -ljson_extension -lparquet_extension -ltpcds_extension -ltpch_extension -lduckdb_fastpforlib -lduckdb_fmt -lduckdb_fsst -lduckdb_hyperloglog -lduckdb_mbedtls -lduckdb_miniz -lduckdb_pg_query -lduckdb_re2 -lduckdb_skiplistlib -lduckdb_utf8proc -lduckdb_yyjson -lduckdb_zstd -llibdummy_static_extension_loader -lws2_32 -lwsock32 -lrstrtmgr -lstdc++ -lm --static -L${SRCDIR}
 #include <duckdb.h>
 */
 import "C"
-


### PR DESCRIPTION
`libdummy_static_extension_loader.a` is missing from all the `lib/*/prebuilt.go` files.

We should also add the actual static library file once v1.5 Variegata is released.