### PR TITLE
Add Streaming C APIs

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -1284,6 +1284,7 @@ func ResultGetChunk(res Result, index IdxT) DataChunk {
 }
 
 // ResultIsStreaming wraps duckdb_result_is_streaming.
+// Deprecated: ResultIsStreaming is deprecated.
 func ResultIsStreaming(res Result) bool {
 	return bool(C.duckdb_result_is_streaming(res.data))
 }
@@ -1653,6 +1654,7 @@ func ExecutePrepared(preparedStmt PreparedStatement, outRes *Result) State {
 
 // ExecutePreparedStreaming wraps duckdb_execute_prepared_streaming.
 // outRes must be destroyed with DestroyResult.
+// Deprecated: ExecutePreparedStreaming is deprecated.
 func ExecutePreparedStreaming(preparedStmt PreparedStatement, outRes *Result) State {
 	if debugMode {
 		incrAllocCount("res")
@@ -1727,6 +1729,7 @@ func PendingPrepared(preparedStmt PreparedStatement, outPendingRes *PendingResul
 
 // PendingPreparedStreaming wraps duckdb_pending_prepared_streaming.
 // outPendingRes must be destroyed with DestroyPending.
+// Deprecated: PendingPreparedStreaming is deprecated.
 func PendingPreparedStreaming(preparedStmt PreparedStatement, outPendingRes *PendingResult) State {
 	var pendingRes C.duckdb_pending_result
 	state := C.duckdb_pending_prepared_streaming(preparedStmt.data(), &pendingRes)
@@ -3750,6 +3753,7 @@ func TableDescriptionGetColumnName(desc TableDescription, index IdxT) string {
 // Returns a data chunk from the streaming result.
 // The returned data chunk must be destroyed with DestroyDataChunk.
 // Returns a data chunk with size 0 when the result is exhausted.
+// Deprecated: StreamFetchChunk is deprecated.
 func StreamFetchChunk(res Result, outChunk *DataChunk) State {
 	chunk := C.duckdb_stream_fetch_chunk(res.data)
 	// duckdb_stream_fetch_chunk returns NULL if the result has an error.


### PR DESCRIPTION
Add bindings for the duckdb C APIs needed to support streaming results: duckdb_pending_prepared_streaming, duckdb_execute_prepared_streaming, duckdb_result_is_streaming, duckdb_stream_fetch_chunk. 

