### PR TITLE
Free prepared statement column name c string

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -1502,6 +1502,7 @@ func PreparedStatementColumnCount(preparedStmt PreparedStatement) IdxT {
 
 func PreparedStatementColumnName(preparedStmt PreparedStatement, index IdxT) string {
 	name := C.duckdb_prepared_statement_column_name(preparedStmt.data(), index)
+	defer Free(unsafe.Pointer(name))
 	return C.GoString(name)
 }
 


### PR DESCRIPTION
`duckdb_prepared_statement_column_name` c api [creates a copy of the column name string](https://github.com/duckdb/duckdb/blob/9612b5bea5a6df924daf5ce696d6992df2483bfe/src/main/capi/prepared-c.cpp#L202) and the returned string should be freed.