### PR TITLE
Fix CreateMapValue to use keys correctly

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -2371,7 +2371,7 @@ func CreateArrayValue(logicalType LogicalType, values []Value) Value {
 // CreateMapValue wraps duckdb_create_map_value.
 // The return value must be destroyed with DestroyValue.
 func CreateMapValue(logicalType LogicalType, keys []Value, values []Value) Value {
-	keyValuesPtr := allocValues(values)
+	keyValuesPtr := allocValues(keys)
 	defer Free(unsafe.Pointer(keyValuesPtr))
 
 	valueValuesPtr := allocValues(values)


### PR DESCRIPTION
This was setting the values as the keys.

Required for PR to allow binding maps during queries and appender calls.