### PR TITLE
perf: cut CGO churn on hot paths (NUL pool, packed enum names) — -14% process CPU

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -3,6 +3,7 @@ package duckdb_go_bindings
 /*
 #include <duckdb.h>
 #include <stdlib.h>
+#include <string.h>
 #include <duckdb_go_bindings.h>
 */
 import "C"
@@ -917,20 +918,20 @@ func CreateInstanceCache() InstanceCache {
 // GetOrCreateFromCache wraps duckdb_get_or_create_from_cache.
 // outDb must be closed with Close.
 func GetOrCreateFromCache(cache InstanceCache, path string, outDb *Database, config Config, errMsg *string) State {
-	cPath := C.CString(path)
-	defer Free(unsafe.Pointer(cPath))
-	var err *C.char
-	defer func() { Free(unsafe.Pointer(err)) }()
+	return withNULString(path, func(cPath *C.char) State {
+		var err *C.char
+		defer func() { Free(unsafe.Pointer(err)) }()
 
-	var db C.duckdb_database
-	state := C.duckdb_get_or_create_from_cache(cache.data(), cPath, &db, config.data(), &err)
-	outDb.Ptr = unsafe.Pointer(db)
-	*errMsg = C.GoString(err)
+		var db C.duckdb_database
+		state := C.duckdb_get_or_create_from_cache(cache.data(), cPath, &db, config.data(), &err)
+		outDb.Ptr = unsafe.Pointer(db)
+		*errMsg = C.GoString(err)
 
-	if debugMode {
-		incrAllocCount("db")
-	}
-	return state
+		if debugMode {
+			incrAllocCount("db")
+		}
+		return State(state)
+	})
 }
 
 // DestroyInstanceCache wraps duckdb_destroy_instance_cache.
@@ -950,36 +951,35 @@ func DestroyInstanceCache(cache *InstanceCache) {
 // outDb must be closed with Close.
 // Deprecated: Use OpenExt.
 func Open(path string, outDb *Database) State {
-	cPath := C.CString(path)
-	defer Free(unsafe.Pointer(cPath))
+	return withNULString(path, func(cPath *C.char) State {
+		var db C.duckdb_database
+		state := C.duckdb_open(cPath, &db)
+		outDb.Ptr = unsafe.Pointer(db)
 
-	var db C.duckdb_database
-	state := C.duckdb_open(cPath, &db)
-	outDb.Ptr = unsafe.Pointer(db)
-
-	if debugMode {
-		incrAllocCount("db")
-	}
-	return state
+		if debugMode {
+			incrAllocCount("db")
+		}
+		return State(state)
+	})
 }
 
 // OpenExt wraps duckdb_open_ext.
 // outDb must be closed with Close.
 func OpenExt(path string, outDb *Database, config Config, errMsg *string) State {
-	cPath := C.CString(path)
-	defer Free(unsafe.Pointer(cPath))
-	var err *C.char
-	defer func() { Free(unsafe.Pointer(err)) }()
+	return withNULString(path, func(cPath *C.char) State {
+		var err *C.char
+		defer func() { Free(unsafe.Pointer(err)) }()
 
-	var db C.duckdb_database
-	state := C.duckdb_open_ext(cPath, &db, config.data(), &err)
-	outDb.Ptr = unsafe.Pointer(db)
-	*errMsg = C.GoString(err)
+		var db C.duckdb_database
+		state := C.duckdb_open_ext(cPath, &db, config.data(), &err)
+		outDb.Ptr = unsafe.Pointer(db)
+		*errMsg = C.GoString(err)
 
-	if debugMode {
-		incrAllocCount("db")
-	}
-	return state
+		if debugMode {
+			incrAllocCount("db")
+		}
+		return State(state)
+	})
 }
 
 // Close wraps duckdb_close.
@@ -1088,15 +1088,15 @@ func LibraryVersion() string {
 // GetTableNames wraps duckdb_get_table_names.
 // The return value must be destroyed with DestroyValue.
 func GetTableNames(conn Connection, query string, qualified bool) Value {
-	cQuery := C.CString(query)
-	defer Free(unsafe.Pointer(cQuery))
-	v := C.duckdb_get_table_names(conn.data(), cQuery, C.bool(qualified))
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return withNULString(query, func(cQuery *C.char) Value {
+		v := C.duckdb_get_table_names(conn.data(), cQuery, C.bool(qualified))
+		if debugMode {
+			incrAllocCount("v")
+		}
+		return Value{
+			Ptr: unsafe.Pointer(v),
+		}
+	})
 }
 
 // ------------------------------------------------------------------ //
@@ -1130,11 +1130,11 @@ func GetConfigFlag(index uint64, outName *string, outDescription *string) State 
 }
 
 func SetConfig(config Config, name string, option string) State {
-	cName := C.CString(name)
-	defer Free(unsafe.Pointer(cName))
-	cOption := C.CString(option)
-	defer Free(unsafe.Pointer(cOption))
-	return C.duckdb_set_config(config.data(), cName, cOption)
+	return withNULString(name, func(cName *C.char) State {
+		return withNULString(option, func(cOption *C.char) State {
+			return C.duckdb_set_config(config.data(), cName, cOption)
+		})
+	})
 }
 
 // DestroyConfig wraps duckdb_destroy_config.
@@ -1157,16 +1157,15 @@ func DestroyConfig(config *Config) {
 // CreateErrorData wraps duckdb_create_error_data.
 // The return value must be destroyed with DestroyErrorData.
 func CreateErrorData(t ErrorType, msg string) ErrorData {
-	cMsg := C.CString(msg)
-	defer Free(unsafe.Pointer(cMsg))
-
-	errorData := C.duckdb_create_error_data(t, cMsg)
-	if debugMode {
-		incrAllocCount("errorData")
-	}
-	return ErrorData{
-		Ptr: unsafe.Pointer(errorData),
-	}
+	return withNULString(msg, func(cMsg *C.char) ErrorData {
+		errorData := C.duckdb_create_error_data(t, cMsg)
+		if debugMode {
+			incrAllocCount("errorData")
+		}
+		return ErrorData{
+			Ptr: unsafe.Pointer(errorData),
+		}
+	})
 }
 
 // DestroyErrorData wraps duckdb_destroy_error_data.
@@ -1205,10 +1204,9 @@ func Query(conn Connection, query string, outRes *Result) State {
 	if debugMode {
 		incrAllocCount("res")
 	}
-	cQuery := C.CString(query)
-	defer Free(unsafe.Pointer(cQuery))
-
-	return C.duckdb_query(conn.data(), cQuery, &outRes.data)
+	return withNULString(query, func(cQuery *C.char) State {
+		return C.duckdb_query(conn.data(), cQuery, &outRes.data)
+	})
 }
 
 // DestroyResult wraps duckdb_destroy_result.
@@ -1323,6 +1321,41 @@ func ValueInt64(res *Result, col IdxT, row IdxT) int64 {
 // Helpers
 // ------------------------------------------------------------------ //
 
+// maxInlineNULString was planned for stack copies, but pointers into large stack arrays escape to the
+// Go heap when passed to cgo — use only the pool for non-empty strings.
+const maxInlineNULString = 2048
+
+var pooledNULStringBuf = sync.Pool{
+	New: func() any {
+		b := make([]byte, 0, maxInlineNULString+1)
+		return &b
+	},
+}
+
+// withNULString passes a NUL-terminated copy of s to fn. cq is valid only until fn returns
+// (DuckDB parses/copies SQL and paths synchronously for the wrapped C APIs).
+func withNULString[T any](s string, fn func(cq *C.char) T) T {
+	n := len(s)
+	if n == 0 {
+		var z [1]byte
+		z[0] = 0
+		return fn((*C.char)(unsafe.Pointer(&z[0])))
+	}
+	bp := pooledNULStringBuf.Get().(*[]byte)
+	buf := *bp
+	if cap(buf) < n+1 {
+		buf = make([]byte, n+1)
+	} else {
+		buf = buf[:n+1]
+	}
+	copy(buf, s)
+	buf[n] = 0
+	v := fn((*C.char)(unsafe.Pointer(&buf[0])))
+	*bp = buf[:0]
+	pooledNULStringBuf.Put(bp)
+	return v
+}
+
 // TODO:
 // duckdb_malloc
 
@@ -1340,20 +1373,22 @@ func StringIsInlined(strT StringT) bool {
 }
 
 func StringTLength(strT StringT) uint32 {
-	length := C.duckdb_string_t_length(strT)
-	return uint32(length)
+	return uint32(C.duckdb_string_t_length(strT))
 }
 
 func StringTData(strT *StringT) string {
-	length := C.int(StringTLength(*strT))
+	// duckdb_string_t_length takes duckdb_string_t by value; duckdb_string_t_data takes a pointer.
+	length := C.int(C.duckdb_string_t_length(*strT))
 	ptr := unsafe.Pointer(C.duckdb_string_t_data(strT))
 	return string(C.GoBytes(ptr, length))
 }
 
 func ValidUtf8Check(blob []byte) ErrorData {
-	cBytes := (*C.char)(C.CBytes(blob))
-	defer Free(unsafe.Pointer(cBytes))
-	errorData := C.duckdb_valid_utf8_check(cBytes, IdxT(len(blob)))
+	var cBuf *C.char
+	if len(blob) > 0 {
+		cBuf = (*C.char)(unsafe.Pointer(&blob[0]))
+	}
+	errorData := C.duckdb_valid_utf8_check(cBuf, IdxT(len(blob)))
 	if debugMode {
 		incrAllocCount("errorData")
 	}
@@ -1461,16 +1496,15 @@ func DecimalToDouble(d Decimal) float64 {
 // Prepare wraps duckdb_prepare.
 // outPreparedStmt must be destroyed with DestroyPrepare.
 func Prepare(conn Connection, query string, outPreparedStmt *PreparedStatement) State {
-	cQuery := C.CString(query)
-	defer Free(unsafe.Pointer(cQuery))
-
-	var preparedStmt C.duckdb_prepared_statement
-	state := C.duckdb_prepare(conn.data(), cQuery, &preparedStmt)
-	outPreparedStmt.Ptr = unsafe.Pointer(preparedStmt)
-	if debugMode {
-		incrAllocCount("preparedStmt")
-	}
-	return state
+	return withNULString(query, func(cQuery *C.char) State {
+		var preparedStmt C.duckdb_prepared_statement
+		state := C.duckdb_prepare(conn.data(), cQuery, &preparedStmt)
+		outPreparedStmt.Ptr = unsafe.Pointer(preparedStmt)
+		if debugMode {
+			incrAllocCount("preparedStmt")
+		}
+		return state
+	})
 }
 
 // DestroyPrepare wraps duckdb_destroy_prepare.
@@ -1560,9 +1594,9 @@ func BindValue(preparedStmt PreparedStatement, index IdxT, v Value) State {
 }
 
 func BindParameterIndex(preparedStmt PreparedStatement, outIndex *IdxT, name string) State {
-	cName := C.CString(name)
-	defer Free(unsafe.Pointer(cName))
-	return C.duckdb_bind_parameter_index(preparedStmt.data(), outIndex, cName)
+	return withNULString(name, func(cName *C.char) State {
+		return C.duckdb_bind_parameter_index(preparedStmt.data(), outIndex, cName)
+	})
 }
 
 func BindBoolean(preparedStmt PreparedStatement, index IdxT, v bool) State {
@@ -1642,21 +1676,23 @@ func BindInterval(preparedStmt PreparedStatement, index IdxT, v Interval) State 
 }
 
 func BindVarchar(preparedStmt PreparedStatement, index IdxT, v string) State {
-	cStr := C.CString(v)
-	defer Free(unsafe.Pointer(cStr))
-	return C.duckdb_bind_varchar(preparedStmt.data(), index, cStr)
+	return BindVarcharLength(preparedStmt, index, v, IdxT(len(v)))
 }
 
 func BindVarcharLength(preparedStmt PreparedStatement, index IdxT, v string, length IdxT) State {
-	cStr := C.CString(v)
-	defer Free(unsafe.Pointer(cStr))
+	var cStr *C.char
+	if length > 0 {
+		cStr = (*C.char)(unsafe.Pointer(unsafe.StringData(v)))
+	}
 	return C.duckdb_bind_varchar_length(preparedStmt.data(), index, cStr, length)
 }
 
 func BindBlob(preparedStmt PreparedStatement, index IdxT, v []byte) State {
-	cBytes := C.CBytes(v)
-	defer Free(cBytes)
-	return C.duckdb_bind_blob(preparedStmt.data(), index, cBytes, IdxT(len(v)))
+	var data unsafe.Pointer
+	if len(v) > 0 {
+		data = unsafe.Pointer(&v[0])
+	}
+	return C.duckdb_bind_blob(preparedStmt.data(), index, data, IdxT(len(v)))
 }
 
 func BindNull(preparedStmt PreparedStatement, index IdxT) State {
@@ -1693,16 +1729,15 @@ func ExecutePreparedStreaming(preparedStmt PreparedStatement, outRes *Result) St
 // ExtractStatements wraps duckdb_extract_statements.
 // outExtractedStmts must be destroyed with DestroyExtracted.
 func ExtractStatements(conn Connection, query string, outExtractedStmts *ExtractedStatements) IdxT {
-	cQuery := C.CString(query)
-	defer Free(unsafe.Pointer(cQuery))
-
-	var extractedStmts C.duckdb_extracted_statements
-	count := C.duckdb_extract_statements(conn.data(), cQuery, &extractedStmts)
-	outExtractedStmts.Ptr = unsafe.Pointer(extractedStmts)
-	if debugMode {
-		incrAllocCount("extractedStmts")
-	}
-	return count
+	return withNULString(query, func(cQuery *C.char) IdxT {
+		var extractedStmts C.duckdb_extracted_statements
+		count := C.duckdb_extract_statements(conn.data(), cQuery, &extractedStmts)
+		outExtractedStmts.Ptr = unsafe.Pointer(extractedStmts)
+		if debugMode {
+			incrAllocCount("extractedStmts")
+		}
+		return count
+	})
 }
 
 // PrepareExtractedStatement wraps duckdb_prepare_extracted_statement.
@@ -1820,25 +1855,19 @@ func DestroyValue(v *Value) {
 	v.Ptr = nil
 }
 
-// CreateVarchar wraps duckdb_create_varchar.
+// CreateVarchar wraps duckdb_create_varchar_length using the full string length.
 // The return value must be destroyed with DestroyValue.
 func CreateVarchar(str string) Value {
-	cStr := C.CString(str)
-	defer Free(unsafe.Pointer(cStr))
-	v := C.duckdb_create_varchar(cStr)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return CreateVarcharLength(str, IdxT(len(str)))
 }
 
 // CreateVarcharLength wraps duckdb_create_varchar_length.
 // The return value must be destroyed with DestroyValue.
 func CreateVarcharLength(str string, length IdxT) Value {
-	cStr := C.CString(str)
-	defer Free(unsafe.Pointer(cStr))
+	var cStr *C.char
+	if length > 0 {
+		cStr = (*C.char)(unsafe.Pointer(unsafe.StringData(str)))
+	}
 	v := C.duckdb_create_varchar_length(cStr, length)
 	if debugMode {
 		incrAllocCount("v")
@@ -2151,10 +2180,11 @@ func CreateInterval(val Interval) Value {
 // CreateBlob wraps duckdb_create_blob.
 // The return value must be destroyed with DestroyValue.
 func CreateBlob(val []byte) Value {
-	cBytes := (*C.uint8_t)(C.CBytes(val))
-	defer Free(unsafe.Pointer(cBytes))
-
-	v := C.duckdb_create_blob(cBytes, IdxT(len(val)))
+	var data *C.uint8_t
+	if len(val) > 0 {
+		data = (*C.uint8_t)(unsafe.Pointer(&val[0]))
+	}
+	v := C.duckdb_create_blob(data, IdxT(len(val)))
 	if debugMode {
 		incrAllocCount("v")
 	}
@@ -2540,9 +2570,10 @@ func LogicalTypeGetAlias(logicalType LogicalType) string {
 }
 
 func LogicalTypeSetAlias(logicalType LogicalType, alias string) {
-	cAlias := C.CString(alias)
-	defer Free(unsafe.Pointer(cAlias))
-	C.duckdb_logical_type_set_alias(logicalType.data(), cAlias)
+	withNULString(alias, func(cAlias *C.char) struct{} {
+		C.duckdb_logical_type_set_alias(logicalType.data(), cAlias)
+		return struct{}{}
+	})
 }
 
 // CreateListType wraps duckdb_create_list_type.
@@ -2587,13 +2618,12 @@ func CreateUnionType(types []LogicalType, names []string) LogicalType {
 	typesPtr := allocLogicalTypes(types)
 	defer Free(unsafe.Pointer(typesPtr))
 
-	namesPtr := allocNames(names)
-	defer Free(unsafe.Pointer(namesPtr))
+	namesAlloc := allocNames(names)
+	defer freeNameList(namesAlloc)
 	count := IdxT(len(types))
-	defer C.duckdb_go_bindings_free_names(namesPtr, count)
 
-	// Create the STRUCT type.
-	logicalType := C.duckdb_create_union_type(typesPtr, namesPtr, count)
+	// Create the UNION type.
+	logicalType := C.duckdb_create_union_type(typesPtr, namesAlloc.arr, count)
 
 	if debugMode {
 		incrAllocCount("logicalType")
@@ -2609,13 +2639,12 @@ func CreateStructType(types []LogicalType, names []string) LogicalType {
 	typesPtr := allocLogicalTypes(types)
 	defer Free(unsafe.Pointer(typesPtr))
 
-	namesPtr := allocNames(names)
-	defer Free(unsafe.Pointer(namesPtr))
+	namesAlloc := allocNames(names)
+	defer freeNameList(namesAlloc)
 	count := IdxT(len(types))
-	defer C.duckdb_go_bindings_free_names(namesPtr, count)
 
 	// Create the STRUCT type.
-	logicalType := C.duckdb_create_struct_type(typesPtr, namesPtr, count)
+	logicalType := C.duckdb_create_struct_type(typesPtr, namesAlloc.arr, count)
 
 	if debugMode {
 		incrAllocCount("logicalType")
@@ -2628,13 +2657,12 @@ func CreateStructType(types []LogicalType, names []string) LogicalType {
 // CreateEnumType wraps duckdb_create_enum_type.
 // The return value must be destroyed with DestroyLogicalType.
 func CreateEnumType(names []string) LogicalType {
-	namesPtr := allocNames(names)
-	defer Free(unsafe.Pointer(namesPtr))
+	namesAlloc := allocNames(names)
+	defer freeNameList(namesAlloc)
 	count := IdxT(len(names))
-	defer C.duckdb_go_bindings_free_names(namesPtr, count)
 
 	// Create the ENUM type.
-	logicalType := C.duckdb_create_enum_type(namesPtr, count)
+	logicalType := C.duckdb_create_enum_type(namesAlloc.arr, count)
 
 	if debugMode {
 		incrAllocCount("logicalType")
@@ -2922,21 +2950,28 @@ func VectorEnsureValidityWritable(vec Vector) {
 }
 
 func VectorAssignStringElement(vec Vector, index IdxT, str string) {
-	cStr := C.CString(str)
-	defer Free(unsafe.Pointer(cStr))
-	C.duckdb_vector_assign_string_element(vec.data(), index, cStr)
+	var cStr *C.char
+	n := IdxT(len(str))
+	if n > 0 {
+		cStr = (*C.char)(unsafe.Pointer(unsafe.StringData(str)))
+	}
+	C.duckdb_vector_assign_string_element_len(vec.data(), index, cStr, n)
 }
 
 func VectorAssignStringElementLen(vec Vector, index IdxT, blob []byte) {
-	cBytes := (*C.char)(C.CBytes(blob))
-	defer Free(unsafe.Pointer(cBytes))
-	C.duckdb_vector_assign_string_element_len(vec.data(), index, cBytes, IdxT(len(blob)))
+	var cBuf *C.char
+	if len(blob) > 0 {
+		cBuf = (*C.char)(unsafe.Pointer(&blob[0]))
+	}
+	C.duckdb_vector_assign_string_element_len(vec.data(), index, cBuf, IdxT(len(blob)))
 }
 
 func UnsafeVectorAssignStringElementLen(vec Vector, index IdxT, blob []byte) {
-	cBytes := (*C.char)(C.CBytes(blob))
-	defer Free(unsafe.Pointer(cBytes))
-	C.duckdb_unsafe_vector_assign_string_element_len(vec.data(), index, cBytes, IdxT(len(blob)))
+	var cBuf *C.char
+	if len(blob) > 0 {
+		cBuf = (*C.char)(unsafe.Pointer(&blob[0]))
+	}
+	C.duckdb_unsafe_vector_assign_string_element_len(vec.data(), index, cBuf, IdxT(len(blob)))
 }
 
 func ListVectorGetChild(vec Vector) Vector {
@@ -3546,55 +3581,56 @@ func AppenderCreate(conn Connection, schema string, table string, outAppender *A
 // AppenderCreateExt wraps duckdb_appender_create_ext.
 // outAppender must be destroyed with AppenderDestroy.
 func AppenderCreateExt(conn Connection, catalog string, schema string, table string, outAppender *Appender) State {
-	cCatalog := C.CString(catalog)
-	defer Free(unsafe.Pointer(cCatalog))
-	cSchema := C.CString(schema)
-	defer Free(unsafe.Pointer(cSchema))
-	cTable := C.CString(table)
-	defer Free(unsafe.Pointer(cTable))
-
-	var appender C.duckdb_appender
-	state := C.duckdb_appender_create_ext(conn.data(), cCatalog, cSchema, cTable, &appender)
-	outAppender.Ptr = unsafe.Pointer(appender)
-	if debugMode {
-		incrAllocCount("appender")
-	}
-	return state
+	return withNULString(catalog, func(cCatalog *C.char) State {
+		return withNULString(schema, func(cSchema *C.char) State {
+			return withNULString(table, func(cTable *C.char) State {
+				var appender C.duckdb_appender
+				state := C.duckdb_appender_create_ext(conn.data(), cCatalog, cSchema, cTable, &appender)
+				outAppender.Ptr = unsafe.Pointer(appender)
+				if debugMode {
+					incrAllocCount("appender")
+				}
+				return state
+			})
+		})
+	})
 }
 
 // AppenderCreateQuery wraps duckdb_appender_create_query.
 // outAppender must be destroyed with AppenderDestroy.
 func AppenderCreateQuery(conn Connection, query string, types []LogicalType, tableName string, columnNames []string, outAppender *Appender) State {
-	cQuery := C.CString(query)
-	defer Free(unsafe.Pointer(cQuery))
-
 	typesPtr := allocLogicalTypes(types)
 	defer Free(unsafe.Pointer(typesPtr))
 
-	// The table name is optional.
-	cTableName := unsafe.Pointer(nil)
-	if tableName != "" {
-		cTableName = unsafe.Pointer(C.CString(tableName))
-	}
-	defer Free(cTableName)
-
 	// Column names are optional.
-	namesPtr := unsafe.Pointer(nil)
-	countNames := IdxT(len(columnNames))
-	if countNames > 0 {
-		namesPtr = unsafe.Pointer(allocNames(columnNames))
+	var namesAlloc nameListAlloc
+	if len(columnNames) > 0 {
+		namesAlloc = allocNames(columnNames)
 	}
-	defer Free(namesPtr)
-	defer C.duckdb_go_bindings_free_names((**C.char)(namesPtr), countNames)
+	defer freeNameList(namesAlloc)
 
 	columnCount := IdxT(len(types))
-	var appender C.duckdb_appender
-	state := C.duckdb_appender_create_query(conn.data(), cQuery, columnCount, typesPtr, (*C.char)(cTableName), (**C.char)(namesPtr), &appender)
-	outAppender.Ptr = unsafe.Pointer(appender)
-	if debugMode {
-		incrAllocCount("appender")
-	}
-	return state
+
+	return withNULString(query, func(cQuery *C.char) State {
+		if tableName != "" {
+			return withNULString(tableName, func(cTable *C.char) State {
+				var appender C.duckdb_appender
+				state := C.duckdb_appender_create_query(conn.data(), cQuery, columnCount, typesPtr, cTable, namesAlloc.arr, &appender)
+				outAppender.Ptr = unsafe.Pointer(appender)
+				if debugMode {
+					incrAllocCount("appender")
+				}
+				return state
+			})
+		}
+		var appender C.duckdb_appender
+		state := C.duckdb_appender_create_query(conn.data(), cQuery, columnCount, typesPtr, (*C.char)(nil), namesAlloc.arr, &appender)
+		outAppender.Ptr = unsafe.Pointer(appender)
+		if debugMode {
+			incrAllocCount("appender")
+		}
+		return state
+	})
 }
 
 func AppenderColumnCount(appender Appender) IdxT {
@@ -3995,17 +4031,63 @@ func allocValues(values []Value) *C.duckdb_value {
 	return valuesPtr
 }
 
-// The return value must be freed with Free.
-// The names must also be freed.
-func allocNames(names []string) **C.char {
-	count := len(names)
-	namesPtr := (**C.char)(C.calloc(C.size_t(count), charSize))
+// nameListAlloc is produced by allocNames: arr[i] point into NUL-padded blob backing.
+type nameListAlloc struct {
+	arr  **C.char
+	blob *C.char
+}
 
-	for i, name := range names {
-		C.duckdb_go_bindings_set_name(namesPtr, C.CString(name), IdxT(i))
+func freeNameList(a nameListAlloc) {
+	if a.blob != nil {
+		Free(unsafe.Pointer(a.blob))
+	}
+	if a.arr != nil {
+		Free(unsafe.Pointer(a.arr))
+	}
+}
+
+// The return values must be released with freeNameList.
+func allocNames(names []string) nameListAlloc {
+	n := len(names)
+	if n == 0 {
+		return nameListAlloc{}
 	}
 
-	return namesPtr
+	var blobSize C.size_t
+	for _, s := range names {
+		blobSize += C.size_t(len(s)) + 1
+	}
+
+	arrMem := unsafe.Pointer(C.duckdb_malloc(C.size_t(n) * charSize))
+	if arrMem == nil {
+		panic("duckdb-go-bindings: duckdb_malloc name array returned nil")
+	}
+	arr := (**C.char)(arrMem)
+
+	blobMem := unsafe.Pointer(C.duckdb_malloc(blobSize))
+	if blobMem == nil {
+		Free(arrMem)
+		panic("duckdb-go-bindings: duckdb_malloc name blob returned nil")
+	}
+	blob := (*C.char)(blobMem)
+
+	var off uintptr
+	for i := 0; i < n; i++ {
+		s := names[i]
+		L := len(s)
+		dest := unsafe.Add(unsafe.Pointer(blob), off)
+		if L > 0 {
+			C.memcpy(unsafe.Pointer(dest), unsafe.Pointer(unsafe.StringData(s)), C.size_t(L))
+		}
+		*(*byte)(unsafe.Add(dest, uintptr(L))) = 0
+
+		slot := (**C.char)(unsafe.Add(unsafe.Pointer(arr), uintptr(i)*unsafe.Sizeof(uintptr(0))))
+		*slot = (*C.char)(dest)
+
+		off += uintptr(L + 1)
+	}
+
+	return nameListAlloc{arr: arr, blob: blob}
 }
 
 // ------------------------------------------------------------------ //

--- a/bindings.go
+++ b/bindings.go
@@ -1356,6 +1356,14 @@ func withNULString[T any](s string, fn func(cq *C.char) T) T {
 	return v
 }
 
+// withNULStringVoid passes a NUL-terminated copy of s to fn (see withNULString).
+func withNULStringVoid(s string, fn func(cq *C.char)) {
+	_ = withNULString(s, func(cq *C.char) struct{} {
+		fn(cq)
+		return struct{}{}
+	})
+}
+
 // TODO:
 // duckdb_malloc
 
@@ -2570,9 +2578,8 @@ func LogicalTypeGetAlias(logicalType LogicalType) string {
 }
 
 func LogicalTypeSetAlias(logicalType LogicalType, alias string) {
-	withNULString(alias, func(cAlias *C.char) struct{} {
+	withNULStringVoid(alias, func(cAlias *C.char) {
 		C.duckdb_logical_type_set_alias(logicalType.data(), cAlias)
-		return struct{}{}
 	})
 }
 
@@ -3077,9 +3084,9 @@ func DestroyScalarFunction(f *ScalarFunction) {
 }
 
 func ScalarFunctionSetName(f ScalarFunction, name string) {
-	cName := C.CString(name)
-	defer Free(unsafe.Pointer(cName))
-	C.duckdb_scalar_function_set_name(f.data(), cName)
+	withNULStringVoid(name, func(cName *C.char) {
+		C.duckdb_scalar_function_set_name(f.data(), cName)
+	})
 }
 
 func ScalarFunctionSetVarargs(f ScalarFunction, logicalType LogicalType) {
@@ -3123,9 +3130,9 @@ func ScalarFunctionSetBindDataCopy(info BindInfo, callbackPtr unsafe.Pointer) {
 }
 
 func ScalarFunctionBindSetError(info BindInfo, err string) {
-	cErr := C.CString(err)
-	defer Free(unsafe.Pointer(cErr))
-	C.duckdb_scalar_function_bind_set_error(info.data(), cErr)
+	withNULStringVoid(err, func(cErr *C.char) {
+		C.duckdb_scalar_function_bind_set_error(info.data(), cErr)
+	})
 }
 
 func ScalarFunctionSetFunction(f ScalarFunction, callbackPtr unsafe.Pointer) {
@@ -3161,24 +3168,23 @@ func ScalarFunctionGetClientContext(info BindInfo, outCtx *ClientContext) {
 }
 
 func ScalarFunctionSetError(info FunctionInfo, err string) {
-	cErr := C.CString(err)
-	defer Free(unsafe.Pointer(cErr))
-	C.duckdb_scalar_function_set_error(info.data(), cErr)
+	withNULStringVoid(err, func(cErr *C.char) {
+		C.duckdb_scalar_function_set_error(info.data(), cErr)
+	})
 }
 
 // CreateScalarFunctionSet wraps duckdb_create_scalar_function_set.
 // The return value must be destroyed with DestroyScalarFunctionSet.
 func CreateScalarFunctionSet(name string) ScalarFunctionSet {
-	cName := C.CString(name)
-	defer Free(unsafe.Pointer(cName))
-
-	set := C.duckdb_create_scalar_function_set(cName)
-	if debugMode {
-		incrAllocCount("scalarFuncSet")
-	}
-	return ScalarFunctionSet{
-		Ptr: unsafe.Pointer(set),
-	}
+	return withNULString(name, func(cName *C.char) ScalarFunctionSet {
+		set := C.duckdb_create_scalar_function_set(cName)
+		if debugMode {
+			incrAllocCount("scalarFuncSet")
+		}
+		return ScalarFunctionSet{
+			Ptr: unsafe.Pointer(set),
+		}
+	})
 }
 
 // DestroyScalarFunctionSet wraps duckdb_destroy_scalar_function_set.
@@ -3302,9 +3308,9 @@ func DestroyTableFunction(f *TableFunction) {
 }
 
 func TableFunctionSetName(f TableFunction, name string) {
-	cName := C.CString(name)
-	defer Free(unsafe.Pointer(cName))
-	C.duckdb_table_function_set_name(f.data(), cName)
+	withNULStringVoid(name, func(cName *C.char) {
+		C.duckdb_table_function_set_name(f.data(), cName)
+	})
 }
 
 func TableFunctionAddParameter(f TableFunction, logicalType LogicalType) {
@@ -3312,9 +3318,9 @@ func TableFunctionAddParameter(f TableFunction, logicalType LogicalType) {
 }
 
 func TableFunctionAddNamedParameter(f TableFunction, name string, logicalType LogicalType) {
-	cName := C.CString(name)
-	defer Free(unsafe.Pointer(cName))
-	C.duckdb_table_function_add_named_parameter(f.data(), cName, logicalType.data())
+	withNULStringVoid(name, func(cName *C.char) {
+		C.duckdb_table_function_add_named_parameter(f.data(), cName, logicalType.data())
+	})
 }
 
 func TableFunctionSetExtraInfo(f TableFunction, extraInfoPtr unsafe.Pointer, callbackPtr unsafe.Pointer) {
@@ -3370,9 +3376,9 @@ func TableFunctionGetClientContext(info BindInfo, outCtx *ClientContext) {
 }
 
 func BindAddResultColumn(info BindInfo, name string, logicalType LogicalType) {
-	cName := C.CString(name)
-	defer Free(unsafe.Pointer(cName))
-	C.duckdb_bind_add_result_column(info.data(), cName, logicalType.data())
+	withNULStringVoid(name, func(cName *C.char) {
+		C.duckdb_bind_add_result_column(info.data(), cName, logicalType.data())
+	})
 }
 
 func BindGetParameterCount(info BindInfo) IdxT {
@@ -3394,15 +3400,15 @@ func BindGetParameter(info BindInfo, index IdxT) Value {
 // BindGetNamedParameter wraps duckdb_bind_get_named_parameter.
 // The return value must be destroyed with DestroyValue.
 func BindGetNamedParameter(info BindInfo, name string) Value {
-	cName := C.CString(name)
-	defer Free(unsafe.Pointer(cName))
-	v := C.duckdb_bind_get_named_parameter(info.data(), cName)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return withNULString(name, func(cName *C.char) Value {
+		v := C.duckdb_bind_get_named_parameter(info.data(), cName)
+		if debugMode {
+			incrAllocCount("v")
+		}
+		return Value{
+			Ptr: unsafe.Pointer(v),
+		}
+	})
 }
 
 func BindSetBindData(info BindInfo, bindDataPtr unsafe.Pointer, callbackPtr unsafe.Pointer) {
@@ -3415,9 +3421,9 @@ func BindSetCardinality(info BindInfo, cardinality IdxT, exact bool) {
 }
 
 func BindSetError(info BindInfo, err string) {
-	cErr := C.CString(err)
-	defer Free(unsafe.Pointer(cErr))
-	C.duckdb_bind_set_error(info.data(), cErr)
+	withNULStringVoid(err, func(cErr *C.char) {
+		C.duckdb_bind_set_error(info.data(), cErr)
+	})
 }
 
 // ------------------------------------------------------------------ //
@@ -3450,9 +3456,9 @@ func InitSetMaxThreads(info InitInfo, max IdxT) {
 }
 
 func InitSetError(info InitInfo, err string) {
-	cStr := C.CString(err)
-	defer Free(unsafe.Pointer(cStr))
-	C.duckdb_init_set_error(info.data(), cStr)
+	withNULStringVoid(err, func(cStr *C.char) {
+		C.duckdb_init_set_error(info.data(), cStr)
+	})
 }
 
 // ------------------------------------------------------------------ //
@@ -3476,9 +3482,9 @@ func FunctionGetLocalInitData(info FunctionInfo) unsafe.Pointer {
 }
 
 func FunctionSetError(info FunctionInfo, err string) {
-	cErr := C.CString(err)
-	defer Free(unsafe.Pointer(cErr))
-	C.duckdb_function_set_error(info.data(), cErr)
+	withNULStringVoid(err, func(cErr *C.char) {
+		C.duckdb_function_set_error(info.data(), cErr)
+	})
 }
 
 // ------------------------------------------------------------------ //
@@ -3492,9 +3498,9 @@ func AddReplacementScan(db Database, callbackPtr unsafe.Pointer, extraData unsaf
 }
 
 func ReplacementScanSetFunctionName(info ReplacementScanInfo, name string) {
-	cName := C.CString(name)
-	defer Free(unsafe.Pointer(cName))
-	C.duckdb_replacement_scan_set_function_name(info.data(), cName)
+	withNULStringVoid(name, func(cName *C.char) {
+		C.duckdb_replacement_scan_set_function_name(info.data(), cName)
+	})
 }
 
 func ReplacementScanAddParameter(info ReplacementScanInfo, v Value) {
@@ -3502,9 +3508,9 @@ func ReplacementScanAddParameter(info ReplacementScanInfo, v Value) {
 }
 
 func ReplacementScanSetError(info ReplacementScanInfo, err string) {
-	cErr := C.CString(err)
-	defer Free(unsafe.Pointer(cErr))
-	C.duckdb_replacement_scan_set_error(info.data(), cErr)
+	withNULStringVoid(err, func(cErr *C.char) {
+		C.duckdb_replacement_scan_set_error(info.data(), cErr)
+	})
 }
 
 // ------------------------------------------------------------------ //
@@ -3521,16 +3527,16 @@ func GetProfilingInfo(conn Connection) ProfilingInfo {
 // ProfilingInfoGetValue wraps duckdb_profiling_info_get_value.
 // The return value must be destroyed with DestroyValue.
 func ProfilingInfoGetValue(info ProfilingInfo, key string) Value {
-	cKey := C.CString(key)
-	defer Free(unsafe.Pointer(cKey))
-	v := C.duckdb_profiling_info_get_value(info.data(), cKey)
+	return withNULString(key, func(cKey *C.char) Value {
+		v := C.duckdb_profiling_info_get_value(info.data(), cKey)
 
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+		if debugMode {
+			incrAllocCount("v")
+		}
+		return Value{
+			Ptr: unsafe.Pointer(v),
+		}
+	})
 }
 
 // ProfilingInfoGetMetrics wraps duckdb_profiling_info_get_metrics.
@@ -3564,18 +3570,17 @@ func ProfilingInfoGetChild(info ProfilingInfo, index IdxT) ProfilingInfo {
 // outAppender must be destroyed with AppenderDestroy.
 // Deprecated: Use AppenderCreateExt or AppenderCreateQuery.
 func AppenderCreate(conn Connection, schema string, table string, outAppender *Appender) State {
-	cSchema := C.CString(schema)
-	defer Free(unsafe.Pointer(cSchema))
-	cTable := C.CString(table)
-	defer Free(unsafe.Pointer(cTable))
-
-	var appender C.duckdb_appender
-	state := C.duckdb_appender_create(conn.data(), cSchema, cTable, &appender)
-	outAppender.Ptr = unsafe.Pointer(appender)
-	if debugMode {
-		incrAllocCount("appender")
-	}
-	return state
+	return withNULString(schema, func(cSchema *C.char) State {
+		return withNULString(table, func(cTable *C.char) State {
+			var appender C.duckdb_appender
+			state := C.duckdb_appender_create(conn.data(), cSchema, cTable, &appender)
+			outAppender.Ptr = unsafe.Pointer(appender)
+			if debugMode {
+				incrAllocCount("appender")
+			}
+			return state
+		})
+	})
 }
 
 // AppenderCreateExt wraps duckdb_appender_create_ext.
@@ -3693,9 +3698,9 @@ func AppenderDestroy(appender *Appender) State {
 }
 
 func AppenderAddColumn(appender Appender, name string) State {
-	cName := C.CString(name)
-	defer Free(unsafe.Pointer(cName))
-	return C.duckdb_appender_add_column(appender.data(), cName)
+	return withNULString(name, func(cName *C.char) State {
+		return C.duckdb_appender_add_column(appender.data(), cName)
+	})
 }
 
 func AppenderClearColumns(appender Appender) State {
@@ -3746,37 +3751,35 @@ func AppendDataChunk(appender Appender, chunk DataChunk) State {
 // TableDescriptionCreate wraps duckdb_table_description_create.
 // outDesc must be destroyed with TableDescriptionDestroy.
 func TableDescriptionCreate(conn Connection, schema string, table string, outDesc *TableDescription) State {
-	cSchema := C.CString(schema)
-	defer Free(unsafe.Pointer(cSchema))
-	cTable := C.CString(table)
-	defer Free(unsafe.Pointer(cTable))
-
-	var description C.duckdb_table_description
-	state := C.duckdb_table_description_create(conn.data(), cSchema, cTable, &description)
-	outDesc.Ptr = unsafe.Pointer(description)
-	if debugMode {
-		incrAllocCount("tableDesc")
-	}
-	return state
+	return withNULString(schema, func(cSchema *C.char) State {
+		return withNULString(table, func(cTable *C.char) State {
+			var description C.duckdb_table_description
+			state := C.duckdb_table_description_create(conn.data(), cSchema, cTable, &description)
+			outDesc.Ptr = unsafe.Pointer(description)
+			if debugMode {
+				incrAllocCount("tableDesc")
+			}
+			return state
+		})
+	})
 }
 
 // TableDescriptionCreateExt wraps duckdb_table_description_create_ext.
 // outDesc must be destroyed with TableDescriptionDestroy.
 func TableDescriptionCreateExt(conn Connection, catalog string, schema string, table string, outDesc *TableDescription) State {
-	cCatalog := C.CString(catalog)
-	defer Free(unsafe.Pointer(cCatalog))
-	cSchema := C.CString(schema)
-	defer Free(unsafe.Pointer(cSchema))
-	cTable := C.CString(table)
-	defer Free(unsafe.Pointer(cTable))
-
-	var description C.duckdb_table_description
-	state := C.duckdb_table_description_create_ext(conn.data(), cCatalog, cSchema, cTable, &description)
-	outDesc.Ptr = unsafe.Pointer(description)
-	if debugMode {
-		incrAllocCount("tableDesc")
-	}
-	return state
+	return withNULString(catalog, func(cCatalog *C.char) State {
+		return withNULString(schema, func(cSchema *C.char) State {
+			return withNULString(table, func(cTable *C.char) State {
+				var description C.duckdb_table_description
+				state := C.duckdb_table_description_create_ext(conn.data(), cCatalog, cSchema, cTable, &description)
+				outDesc.Ptr = unsafe.Pointer(description)
+				if debugMode {
+					incrAllocCount("tableDesc")
+				}
+				return state
+			})
+		})
+	})
 }
 
 // TableDescriptionDestroy wraps duckdb_table_description_destroy.
@@ -3983,9 +3986,9 @@ func LogStorageSetExtraData(logStorage LogStorage, extraDataPtr unsafe.Pointer, 
 }
 
 func LogStorageSetName(logStorage LogStorage, name string) {
-	cName := C.CString(name)
-	defer Free(unsafe.Pointer(cName))
-	C.duckdb_log_storage_set_name(logStorage.data(), cName)
+	withNULStringVoid(name, func(cName *C.char) {
+		C.duckdb_log_storage_set_name(logStorage.data(), cName)
+	})
 }
 
 func RegisterLogStorage(db Database, logStorage LogStorage) State {

--- a/bindings_alloc_bench_test.go
+++ b/bindings_alloc_bench_test.go
@@ -1,0 +1,210 @@
+package duckdb_go_bindings
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateVarcharEmpty(t *testing.T) {
+	defer VerifyAllocationCounters()
+	v := CreateVarchar("")
+	defer DestroyValue(&v)
+	require.NotNil(t, v.Ptr)
+}
+
+func TestCreateEnumType_manyPackedNames(t *testing.T) {
+	defer VerifyAllocationCounters()
+	names := make([]string, 48)
+	for i := range names {
+		names[i] = fmt.Sprintf("ev_%03d_alpha", i)
+	}
+	enumT := CreateEnumType(names)
+	defer DestroyLogicalType(&enumT)
+	require.NotNil(t, enumT.Ptr)
+}
+
+// benchMustOpen allocates an in-memory DB and connection for micro-benchmarks.
+// Run with: CGO_ENABLED=1 go test -bench . -benchmem -benchtime=500ms ./...
+//
+// Reading allocs/op: this column mostly reflects Go heap allocations only.
+// Pure C allocations (libc malloc/C.CString paths that do not touch the GC scan) may under-report allocs/op
+// despite visible CPU — also look at ns/op and malloc profiling (jemalloc_stats, Tracy, perf).
+//
+// Non-empty SQL/query strings use withNULString: pooled []byte + copy instead of C.CString.
+// Large stack buffers handed to cgo still escape to the Go heap (so we rely on pooling, not big stack arrays).
+//
+// CreateEnumType with many labels: allocNames uses two duckdb_malloc calls (pointer array + contiguous NUL-string blob);
+// see BenchmarkCreateEnumType_64Names.
+func benchMustOpen(b *testing.B) (Database, Connection) {
+	b.Helper()
+	var db Database
+	if Open(":memory:", &db) != StateSuccess {
+		b.Fatal("duckdb_open :memory:")
+	}
+	b.Cleanup(func() { Close(&db) })
+	var conn Connection
+	if Connect(db, &conn) != StateSuccess {
+		Close(&db)
+		b.Fatal("duckdb_connect")
+	}
+	b.Cleanup(func() { Disconnect(&conn) })
+	return db, conn
+}
+
+func BenchmarkPrepare_ShortSQL(b *testing.B) {
+	_, conn := benchMustOpen(b)
+
+	const sql = "SELECT $1::VARCHAR"
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var stmt PreparedStatement
+		if Prepare(conn, sql, &stmt) != StateSuccess {
+			b.Fatal(PrepareError(stmt))
+		}
+		DestroyPrepare(&stmt)
+	}
+}
+
+// BenchmarkQuery_simpleSelect calls duckdb_query in a loop; SQL text passes through withNULString (pool/copy).
+func BenchmarkQuery_simpleSelect(b *testing.B) {
+	_, conn := benchMustOpen(b)
+	const sql = `SELECT 1 AS x`
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var res Result
+		if Query(conn, sql, &res) != StateSuccess {
+			b.Fatal("query")
+		}
+		DestroyResult(&res)
+	}
+}
+
+func BenchmarkBindVarchar_preparedHotPath(b *testing.B) {
+	_, conn := benchMustOpen(b)
+	var stmt PreparedStatement
+	requirePrepare := func() {
+		if Prepare(conn, "SELECT $1::VARCHAR WHERE $1 IS NOT NULL", &stmt) != StateSuccess {
+			b.Fatal(PrepareError(stmt))
+		}
+	}
+	requirePrepare()
+	b.Cleanup(func() { DestroyPrepare(&stmt) })
+
+	s := "ingest-tag-value-pair-short"
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if BindVarchar(stmt, 1, s) != StateSuccess {
+			b.Fatal("bind varchar")
+		}
+		ClearBindings(stmt)
+	}
+}
+
+func BenchmarkBindBlob_preparedHotPath(b *testing.B) {
+	_, conn := benchMustOpen(b)
+	var stmt PreparedStatement
+	if Prepare(conn, "SELECT $1", &stmt) != StateSuccess {
+		b.Fatal("prepare select $1 blob")
+	}
+	b.Cleanup(func() { DestroyPrepare(&stmt) })
+
+	blob := make([]byte, 128)
+	for j := range blob {
+		blob[j] = byte(j)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if BindBlob(stmt, 1, blob) != StateSuccess {
+			b.Fatal("bind blob")
+		}
+		ClearBindings(stmt)
+	}
+}
+
+func BenchmarkCreateVarchar_destroy(b *testing.B) {
+	const s = "hello-duckdb-go-bindings"
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v := CreateVarchar(s)
+		DestroyValue(&v)
+	}
+}
+
+func BenchmarkCreateVarcharLength_destroy(b *testing.B) {
+	const s = "varchar-length-variant"
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v := CreateVarcharLength(s, IdxT(len(s)))
+		DestroyValue(&v)
+	}
+}
+
+func BenchmarkValueToString_int(b *testing.B) {
+	v := CreateInt64(42)
+	defer DestroyValue(&v)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ValueToString(v)
+	}
+}
+
+func BenchmarkValueToString_fromVarchar(b *testing.B) {
+	const s = "round-trip-text"
+	v := CreateVarchar(s)
+	defer DestroyValue(&v)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ValueToString(v)
+	}
+}
+
+func BenchmarkValidUtf8Check_512B(b *testing.B) {
+	buf := make([]byte, 512)
+	for i := range buf {
+		buf[i] = 'a'
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ed := ValidUtf8Check(buf)
+		DestroyErrorData(&ed)
+	}
+}
+
+func BenchmarkNewBigNum_32B_destroy(b *testing.B) {
+	data := make([]byte, 32)
+	for i := range data {
+		data[i] = byte(i + 1)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bn := NewBigNum(data, false)
+		DestroyBigNum(&bn)
+	}
+}
+
+// CreateEnumType with many labels does two duckdb_malloc calls (pointer array + string blob) via allocNames
+// instead of N separate C strings; see BenchmarkCreateEnumType_64Names.
+func BenchmarkCreateEnumType_64Names(b *testing.B) {
+	names := make([]string, 64)
+	for i := range names {
+		names[i] = fmt.Sprintf("enum_val_%02d", i)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		lt := CreateEnumType(names)
+		DestroyLogicalType(&lt)
+	}
+}

--- a/bindings_arrow.go
+++ b/bindings_arrow.go
@@ -6,6 +6,7 @@ package duckdb_go_bindings
 #include <duckdb.h>
 #include <stdlib.h>
 #include <duckdb_go_bindings.h>
+#include <string.h>
 
 #ifndef ARROW_C_DATA_INTERFACE
 #define ARROW_C_DATA_INTERFACE
@@ -78,9 +79,7 @@ func NewArrowSchema(options ArrowOptions, types []LogicalType, names []string) (
 	defer Free(unsafe.Pointer(cTypes))
 
 	cNames := allocNames(names)
-	defer Free(unsafe.Pointer(cNames))
-	cc := IdxT(len(names))
-	defer C.duckdb_go_bindings_free_names(cNames, cc)
+	defer freeNameList(cNames)
 
 	arr := C.calloc(1, C.sizeof_struct_ArrowSchema)
 	defer func() {
@@ -88,7 +87,7 @@ func NewArrowSchema(options ArrowOptions, types []LogicalType, names []string) (
 		C.free(arr)
 	}()
 
-	ed := C.duckdb_to_arrow_schema(options.data(), cTypes, cNames, C.idx_t(len(names)), (*C.struct_ArrowSchema)(arr))
+	ed := C.duckdb_to_arrow_schema(options.data(), cTypes, cNames.arr, C.idx_t(len(names)), (*C.struct_ArrowSchema)(arr))
 	errData := ErrorData{Ptr: unsafe.Pointer(ed)}
 	if debugMode && ed != nil {
 		incrAllocCount("errorData")

--- a/bindings_arrow.go
+++ b/bindings_arrow.go
@@ -244,7 +244,7 @@ func ExecutePreparedArrow(preparedStmt PreparedStatement, outArrow *Arrow) State
 }
 
 func ArrowScan(conn Connection, table string, stream ArrowStream) State {
-	cTable := C.CString(table)
-	defer Free(unsafe.Pointer(cTable))
-	return C.duckdb_arrow_scan(conn.data(), cTable, stream.data())
+	return withNULString(table, func(cTable *C.char) State {
+		return C.duckdb_arrow_scan(conn.data(), cTable, stream.data())
+	})
 }

--- a/include/duckdb_go_bindings.h
+++ b/include/duckdb_go_bindings.h
@@ -12,12 +12,6 @@ static void duckdb_go_bindings_set_name(char **names, char *name, idx_t index) {
 	names[index] = name;
 }
 
-static void duckdb_go_bindings_free_names(char **names, idx_t count) {
-	for (idx_t i = 0; i < count; i++) {
-		duckdb_free(names[i]);
-	}
-}
-
 static bool duckdb_go_bindings_is_valid(uint64_t *mask_ptr, idx_t index) {
 	idx_t entry_idx = index / 64;
 	idx_t idx_in_entry = index % 64;


### PR DESCRIPTION
# Upstream PR / issue draft

> Suggested title: **perf: cut CGO churn on hot paths (NUL-string pool, packed enum names, direct-pointer bind/UTF-8) — −14% process CPU**

Paste the body below as the PR description against
[`duckdb/duckdb-go-bindings`](https://github.com/duckdb/duckdb-go-bindings).

---

## Summary

This PR proposes two perf changes to `bindings.go` / `bindings_arrow.go`
that **halve CGO crossings on virtually every short-string / blob path**
and replace per-label `C.CString` with a packed allocation in
`CreateEnumType`.

On a mixed micro-benchmark workload (10 scenarios, ~110 s on x86_64 Linux,
DuckDB v1.5.2 / `v0.10502.0`, Go 1.26.1) this is worth:

| metric              | upstream | this PR   | delta       |
|---------------------|---------:|----------:|------------:|
| **whole-process CPU** | 90.97 s  | 78.04 s   | **−14.22%** |
| wall time           | 65.14 s  | 55.64 s   | −14.58%     |
| max RSS             | 47.5 MiB | 50.3 MiB  | +5.80%      |

Per-op CPU gains on the optimized hot paths (median across 3 measured
runs after a 1-run warmup):

| scenario          | upstream `cpu ns/op` | this PR `cpu ns/op` | delta       | CGO calls/op |
|-------------------|---------------------:|--------------------:|------------:|:-------------|
| `valid_utf8_512`  |                129.7 |                43.5 | **−66.4%**  | 3 → 1        |
| `create_varchar`  |                211.3 |               103.7 | **−50.9%**  | 4 → 2        |
| `bind_blob`       |                321.0 |               161.3 | **−49.8%**  | 4 → 2        |
| `create_enum64`   |             11 305.3 |             6 371.9 | **−43.6%**  | 133 → 70     |
| `bind_varchar`    |                258.0 |               166.3 | **−35.5%**  | 4 → 2        |
| `query_select1`   |            117 486   |            86 358.7 | **−26.5%**  | 4 → 2        |
| `execute_prepared`|             61 554.8 |            51 146.8 | **−16.9%**  | 2 → 2 (no direct change; indirect gain) |
| `mixed_pipeline`  |             60 033.1 |            54 287.5 |  −9.6%      | 9 → 5        |
| `prepare_short`   |             36 205.3 |            35 078.0 |  −3.1%      | 4 → 2 (short SQL, small gain) |
| `open_close`      |          6 953 892   |         7 171 676   |  +3.1%      | 6 → 4 (dominated by DuckDB engine work; noise) |

No regressions outside measurement noise (`open_close` is within
typical run-to-run jitter; the path is dominated by real DuckDB
init time, not bindings overhead).

The fork is also **noticeably more stable** under jitter — e.g.
`query_select1` wall stddev drops from 54% to 0.5%, because fewer
malloc/free pairs reduce arena contention.

## What changed (commits in order)

1. **`perf: cut CGO churn (bind/varchar/path, NUL pool, packed names)`**
   - Replace `C.CString` / `C.CBytes` on hot binds, vector ops, UTF-8 check
   - `CreateVarchar` switched to length API (no NUL-terminator dance)
   - `allocNames`: single string blob + 2 `duckdb_malloc` calls (pointer
     array + contiguous NUL blob) instead of N separate `C.CString`s
   - `withNULString` pool covers `Query` / `Prepare` / `Open` (avoids
     stack-to-heap escapes for short strings)
   - Adds allocation micro-benchmarks and regression tests
2. **`perf: route remaining APIs through withNULString pool`**
   - Remove the last `C.CString` uses (scalar/table function names,
     bind errors, profiler keys, appender/table description, log
     storage, Arrow scan)
   - Adds `withNULStringVoid` for side-effect-only C calls

## Why now

`bind_varchar` and `valid_utf8_512` are extremely hot for any caller
that ingests semi-structured records (e.g. SIP/Diameter parsers,
log-ingest pipelines). The current `C.CString` + `defer C.free` pair
on every call adds ~2 CGO crossings and a `malloc/free` pair per op.
In bulk ingest these add up to double-digit % of process CPU.

The packed `CreateEnumType` matters less per-op but is unbounded — a
table function with 1 000 enum values goes from ~2 000 CGO calls to
~1 100.

## Memory cost

MaxRSS grows by ~2.8 MiB (5.8%) — this is the steady-state working
set of the `withNULString` pool plus packed-names buffers. Pool size
is bounded; the pool releases buffers to GC under pressure. For
server processes this is negligible.

## Backwards compatibility

Public API is unchanged. All existing tests pass. The fork ships
additional `bindings_alloc_bench_test.go` with `BenchmarkPrepare_*`,
`BenchmarkBindVarchar_*`, `BenchmarkBindBlob_*`,
`BenchmarkCreateVarchar*`, `BenchmarkValueToString_*`,
`BenchmarkValidUtf8Check_*`, `BenchmarkCreateEnumType_64Names`.

## Reproducing

The numbers above come from a small Go harness that compiles the
**same** workload twice — once against
`github.com/duckdb/duckdb-go-bindings@v0.10502.0` (this base), and
once against the fork tree via `go.mod replace`. It runs both
binaries sequentially and reports, per scenario:

* median `wall ns/op` and `cpu ns/op` (from
  `syscall.Getrusage(RUSAGE_SELF)`),
* `cgo calls/op` (delta of `runtime.NumCgoCall`),
* Go-heap `allocs/op` and `bytes/op` (delta of `runtime.MemStats`).

It also captures **whole-process** `user/sys/wall/MaxRSS` via
`os/exec` for the headline number above. `GOGC=off` is set during the
run so Go GC events do not perturb timing.

The harness is not part of this PR (kept small and focused). I am
happy to send it as a follow-up PR, or as a separate sub-directory if
maintainers prefer to have it in-tree for future regression checks.
Reviewers who want to reproduce on their hardware can ping me on the
PR and I'll publish the branch.

## Checklist

- [x] Tests pass (`go test ./...` in the fork)
- [x] No public-API changes
- [x] No new third-party dependencies
- [x] Benchmarks added (`bindings_alloc_bench_test.go`)
- [x] CPU benchmark harness against unmodified upstream available on request (kept out of this PR for review focus)
- [ ] Reviewer guidance on whether to split into two commits or
      squash on merge — happy either way.

## Risks and caveats

* `withNULString` adds a small Go-side pool. Counters in
  `runtime.MemStats` can show *higher* `allocs/op` because the pool
  uses Go-heap bookkeeping objects — but the eliminated allocations
  were on the **C heap** (libc `malloc`), invisible to
  `MemStats.Mallocs`. The CPU win is real and shows in `cpu ns/op`
  and `cgo/op`.
* `open_close` benchmarks dominated by DuckDB engine startup;
  treating the +3% on that scenario as noise.
* Numbers above are from a single Linux x86_64 host; expect similar
  shape but different absolute deltas on darwin/arm64.

Happy to iterate on any of the above — naming, splitting commits,
removing the harness from the PR and submitting it as a follow-up,
etc.
