### PR TITLE
perf: pack logical-type name lists (allocNames blob)

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -3,6 +3,7 @@ package duckdb_go_bindings
 /*
 #include <duckdb.h>
 #include <stdlib.h>
+#include <string.h>
 #include <duckdb_go_bindings.h>
 */
 import "C"
@@ -2587,13 +2588,12 @@ func CreateUnionType(types []LogicalType, names []string) LogicalType {
 	typesPtr := allocLogicalTypes(types)
 	defer Free(unsafe.Pointer(typesPtr))
 
-	namesPtr := allocNames(names)
-	defer Free(unsafe.Pointer(namesPtr))
+	namesAlloc := allocNames(names)
+	defer freeNameList(namesAlloc)
 	count := IdxT(len(types))
-	defer C.duckdb_go_bindings_free_names(namesPtr, count)
 
-	// Create the STRUCT type.
-	logicalType := C.duckdb_create_union_type(typesPtr, namesPtr, count)
+	// Create the UNION type.
+	logicalType := C.duckdb_create_union_type(typesPtr, namesAlloc.arr, count)
 
 	if debugMode {
 		incrAllocCount("logicalType")
@@ -2609,13 +2609,12 @@ func CreateStructType(types []LogicalType, names []string) LogicalType {
 	typesPtr := allocLogicalTypes(types)
 	defer Free(unsafe.Pointer(typesPtr))
 
-	namesPtr := allocNames(names)
-	defer Free(unsafe.Pointer(namesPtr))
+	namesAlloc := allocNames(names)
+	defer freeNameList(namesAlloc)
 	count := IdxT(len(types))
-	defer C.duckdb_go_bindings_free_names(namesPtr, count)
 
 	// Create the STRUCT type.
-	logicalType := C.duckdb_create_struct_type(typesPtr, namesPtr, count)
+	logicalType := C.duckdb_create_struct_type(typesPtr, namesAlloc.arr, count)
 
 	if debugMode {
 		incrAllocCount("logicalType")
@@ -2628,13 +2627,12 @@ func CreateStructType(types []LogicalType, names []string) LogicalType {
 // CreateEnumType wraps duckdb_create_enum_type.
 // The return value must be destroyed with DestroyLogicalType.
 func CreateEnumType(names []string) LogicalType {
-	namesPtr := allocNames(names)
-	defer Free(unsafe.Pointer(namesPtr))
+	namesAlloc := allocNames(names)
+	defer freeNameList(namesAlloc)
 	count := IdxT(len(names))
-	defer C.duckdb_go_bindings_free_names(namesPtr, count)
 
 	// Create the ENUM type.
-	logicalType := C.duckdb_create_enum_type(namesPtr, count)
+	logicalType := C.duckdb_create_enum_type(namesAlloc.arr, count)
 
 	if debugMode {
 		incrAllocCount("logicalType")
@@ -3579,17 +3577,15 @@ func AppenderCreateQuery(conn Connection, query string, types []LogicalType, tab
 	defer Free(cTableName)
 
 	// Column names are optional.
-	namesPtr := unsafe.Pointer(nil)
-	countNames := IdxT(len(columnNames))
-	if countNames > 0 {
-		namesPtr = unsafe.Pointer(allocNames(columnNames))
+	var namesAlloc nameListAlloc
+	if len(columnNames) > 0 {
+		namesAlloc = allocNames(columnNames)
 	}
-	defer Free(namesPtr)
-	defer C.duckdb_go_bindings_free_names((**C.char)(namesPtr), countNames)
+	defer freeNameList(namesAlloc)
 
 	columnCount := IdxT(len(types))
 	var appender C.duckdb_appender
-	state := C.duckdb_appender_create_query(conn.data(), cQuery, columnCount, typesPtr, (*C.char)(cTableName), (**C.char)(namesPtr), &appender)
+	state := C.duckdb_appender_create_query(conn.data(), cQuery, columnCount, typesPtr, (*C.char)(cTableName), namesAlloc.arr, &appender)
 	outAppender.Ptr = unsafe.Pointer(appender)
 	if debugMode {
 		incrAllocCount("appender")
@@ -3995,17 +3991,63 @@ func allocValues(values []Value) *C.duckdb_value {
 	return valuesPtr
 }
 
-// The return value must be freed with Free.
-// The names must also be freed.
-func allocNames(names []string) **C.char {
-	count := len(names)
-	namesPtr := (**C.char)(C.calloc(C.size_t(count), charSize))
+// nameListAlloc is produced by allocNames: arr[i] point into NUL-padded blob backing.
+type nameListAlloc struct {
+	arr  **C.char
+	blob *C.char
+}
 
-	for i, name := range names {
-		C.duckdb_go_bindings_set_name(namesPtr, C.CString(name), IdxT(i))
+func freeNameList(a nameListAlloc) {
+	if a.blob != nil {
+		Free(unsafe.Pointer(a.blob))
+	}
+	if a.arr != nil {
+		Free(unsafe.Pointer(a.arr))
+	}
+}
+
+// The return values must be released with freeNameList.
+func allocNames(names []string) nameListAlloc {
+	n := len(names)
+	if n == 0 {
+		return nameListAlloc{}
 	}
 
-	return namesPtr
+	var blobSize C.size_t
+	for _, s := range names {
+		blobSize += C.size_t(len(s)) + 1
+	}
+
+	arrMem := unsafe.Pointer(C.duckdb_malloc(C.size_t(n) * charSize))
+	if arrMem == nil {
+		panic("duckdb-go-bindings: duckdb_malloc name array returned nil")
+	}
+	arr := (**C.char)(arrMem)
+
+	blobMem := unsafe.Pointer(C.duckdb_malloc(blobSize))
+	if blobMem == nil {
+		Free(arrMem)
+		panic("duckdb-go-bindings: duckdb_malloc name blob returned nil")
+	}
+	blob := (*C.char)(blobMem)
+
+	var off uintptr
+	for i := 0; i < n; i++ {
+		s := names[i]
+		L := len(s)
+		dest := unsafe.Add(unsafe.Pointer(blob), off)
+		if L > 0 {
+			C.memcpy(unsafe.Pointer(dest), unsafe.Pointer(unsafe.StringData(s)), C.size_t(L))
+		}
+		*(*byte)(unsafe.Add(dest, uintptr(L))) = 0
+
+		slot := (**C.char)(unsafe.Add(unsafe.Pointer(arr), uintptr(i)*unsafe.Sizeof(uintptr(0))))
+		*slot = (*C.char)(dest)
+
+		off += uintptr(L + 1)
+	}
+
+	return nameListAlloc{arr: arr, blob: blob}
 }
 
 // ------------------------------------------------------------------ //

--- a/bindings.go
+++ b/bindings.go
@@ -3576,11 +3576,7 @@ func AppenderCreateQuery(conn Connection, query string, types []LogicalType, tab
 	}
 	defer Free(cTableName)
 
-	// Column names are optional.
-	var namesAlloc nameListAlloc
-	if len(columnNames) > 0 {
-		namesAlloc = allocNames(columnNames)
-	}
+	namesAlloc := allocNames(columnNames)
 	defer freeNameList(namesAlloc)
 
 	columnCount := IdxT(len(types))
@@ -4034,17 +4030,17 @@ func allocNames(names []string) nameListAlloc {
 	var off uintptr
 	for i := 0; i < n; i++ {
 		s := names[i]
-		L := len(s)
+		slen := len(s)
 		dest := unsafe.Add(unsafe.Pointer(blob), off)
-		if L > 0 {
-			C.memcpy(unsafe.Pointer(dest), unsafe.Pointer(unsafe.StringData(s)), C.size_t(L))
+		if slen > 0 {
+			C.memcpy(unsafe.Pointer(dest), unsafe.Pointer(unsafe.StringData(s)), C.size_t(slen))
 		}
-		*(*byte)(unsafe.Add(dest, uintptr(L))) = 0
+		*(*byte)(unsafe.Add(dest, uintptr(slen))) = 0
 
-		slot := (**C.char)(unsafe.Add(unsafe.Pointer(arr), uintptr(i)*unsafe.Sizeof(uintptr(0))))
+		slot := (**C.char)(unsafe.Add(unsafe.Pointer(arr), uintptr(i)*uintptr(charSize)))
 		*slot = (*C.char)(dest)
 
-		off += uintptr(L + 1)
+		off += uintptr(slen + 1)
 	}
 
 	return nameListAlloc{arr: arr, blob: blob}

--- a/bindings_alloc_bench_test.go
+++ b/bindings_alloc_bench_test.go
@@ -18,23 +18,6 @@ func TestCreateEnumType_manyPackedNames(t *testing.T) {
 	require.NotNil(t, enumT.Ptr)
 }
 
-// benchMustOpen allocates an in-memory DB and connection for micro-benchmarks.
-func benchMustOpen(b *testing.B) (Database, Connection) {
-	b.Helper()
-	var db Database
-	if Open(":memory:", &db) != StateSuccess {
-		b.Fatal("duckdb_open :memory:")
-	}
-	b.Cleanup(func() { Close(&db) })
-	var conn Connection
-	if Connect(db, &conn) != StateSuccess {
-		Close(&db)
-		b.Fatal("duckdb_connect")
-	}
-	b.Cleanup(func() { Disconnect(&conn) })
-	return db, conn
-}
-
 // CreateEnumType with many labels: allocNames uses two duckdb_malloc calls (pointer array + contiguous NUL-string blob).
 func BenchmarkCreateEnumType_64Names(b *testing.B) {
 	names := make([]string, 64)

--- a/bindings_alloc_bench_test.go
+++ b/bindings_alloc_bench_test.go
@@ -1,0 +1,50 @@
+package duckdb_go_bindings
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateEnumType_manyPackedNames(t *testing.T) {
+	defer VerifyAllocationCounters()
+	names := make([]string, 48)
+	for i := range names {
+		names[i] = fmt.Sprintf("ev_%03d_alpha", i)
+	}
+	enumT := CreateEnumType(names)
+	defer DestroyLogicalType(&enumT)
+	require.NotNil(t, enumT.Ptr)
+}
+
+// benchMustOpen allocates an in-memory DB and connection for micro-benchmarks.
+func benchMustOpen(b *testing.B) (Database, Connection) {
+	b.Helper()
+	var db Database
+	if Open(":memory:", &db) != StateSuccess {
+		b.Fatal("duckdb_open :memory:")
+	}
+	b.Cleanup(func() { Close(&db) })
+	var conn Connection
+	if Connect(db, &conn) != StateSuccess {
+		Close(&db)
+		b.Fatal("duckdb_connect")
+	}
+	b.Cleanup(func() { Disconnect(&conn) })
+	return db, conn
+}
+
+// CreateEnumType with many labels: allocNames uses two duckdb_malloc calls (pointer array + contiguous NUL-string blob).
+func BenchmarkCreateEnumType_64Names(b *testing.B) {
+	names := make([]string, 64)
+	for i := range names {
+		names[i] = fmt.Sprintf("enum_val_%02d", i)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		lt := CreateEnumType(names)
+		DestroyLogicalType(&lt)
+	}
+}

--- a/bindings_arrow.go
+++ b/bindings_arrow.go
@@ -78,9 +78,7 @@ func NewArrowSchema(options ArrowOptions, types []LogicalType, names []string) (
 	defer Free(unsafe.Pointer(cTypes))
 
 	cNames := allocNames(names)
-	defer Free(unsafe.Pointer(cNames))
-	cc := IdxT(len(names))
-	defer C.duckdb_go_bindings_free_names(cNames, cc)
+	defer freeNameList(cNames)
 
 	arr := C.calloc(1, C.sizeof_struct_ArrowSchema)
 	defer func() {
@@ -88,7 +86,7 @@ func NewArrowSchema(options ArrowOptions, types []LogicalType, names []string) (
 		C.free(arr)
 	}()
 
-	ed := C.duckdb_to_arrow_schema(options.data(), cTypes, cNames, C.idx_t(len(names)), (*C.struct_ArrowSchema)(arr))
+	ed := C.duckdb_to_arrow_schema(options.data(), cTypes, cNames.arr, C.idx_t(len(names)), (*C.struct_ArrowSchema)(arr))
 	errData := ErrorData{Ptr: unsafe.Pointer(ed)}
 	if debugMode && ed != nil {
 		incrAllocCount("errorData")

--- a/include/duckdb_go_bindings.h
+++ b/include/duckdb_go_bindings.h
@@ -8,10 +8,6 @@ static void duckdb_go_bindings_set_value(duckdb_value *values_ptr, duckdb_value 
 	values_ptr[index] = value;
 }
 
-static void duckdb_go_bindings_set_name(char **names, char *name, idx_t index) {
-	names[index] = name;
-}
-
 static bool duckdb_go_bindings_is_valid(uint64_t *mask_ptr, idx_t index) {
 	idx_t entry_idx = index / 64;
 	idx_t idx_in_entry = index % 64;

--- a/include/duckdb_go_bindings.h
+++ b/include/duckdb_go_bindings.h
@@ -12,12 +12,6 @@ static void duckdb_go_bindings_set_name(char **names, char *name, idx_t index) {
 	names[index] = name;
 }
 
-static void duckdb_go_bindings_free_names(char **names, idx_t count) {
-	for (idx_t i = 0; i < count; i++) {
-		duckdb_free(names[i]);
-	}
-}
-
 static bool duckdb_go_bindings_is_valid(uint64_t *mask_ptr, idx_t index) {
 	idx_t entry_idx = index / 64;
 	idx_t idx_in_entry = index % 64;


### PR DESCRIPTION
## Summary

- Replace per-label `C.CString` in `allocNames` with one pointer array + one contiguous NUL-terminated blob (`duckdb_malloc`), and `freeNameList` to release both.
- Remove `duckdb_go_bindings_free_names` from `include/duckdb_go_bindings.h` (callers free the blob/array only).
- Update `CreateUnionType`, `CreateStructType`, `CreateEnumType`, hybrid `AppenderCreateQuery` (column names only; query/table still use `CString` until a follow-up PR), and Arrow `NewArrowSchema`.
- Add `TestCreateEnumType_manyPackedNames` and `BenchmarkCreateEnumType_64Names`.

This is **PR 1 of 4** splitting the work from [PR #82](https://github.com/duckdb/duckdb-go-bindings/pull/82) as requested for easier review. After this merges, the next branches to rebase onto `upstream/main` and open as separate PRs are:

- `adubovikov:perf/upstream-pr/2-hot-bind-paths` — bind/blob/varchar/vector hot paths without pool
- `adubovikov:perf/upstream-pr/3-nul-pool-core` — `withNULString` pool + Open/Query/Prepare paths
- `adubovikov:perf/upstream-pr/4-nul-pool-sweep` — remaining `CString` routes through the pool

Optional harness (after PR 1–4 land or separately): `adubovikov:perf/upstream-pr/5-cpu-bench-harness` (`cpu_bench/`).

## Test plan

- [x] `CGO_ENABLED=1 go test ./...`
- [x] `CGO_ENABLED=1 go test -tags duckdb_arrow ./...`