### PR TITLE
Centralize allocation accounting with typed counters

### DIFF
--- a/alloc.go
+++ b/alloc.go
@@ -122,67 +122,67 @@ var allocCounts syncMap
 type allocationCounter string
 
 const (
-	vectorAllocation               allocationCounter = "vec"
-	selectionVectorAllocation      allocationCounter = "sel"
-	instanceCacheAllocation        allocationCounter = "cache"
-	databaseAllocation             allocationCounter = "db"
-	connectionAllocation           allocationCounter = "conn"
-	clientContextAllocation        allocationCounter = "ctx"
-	preparedStatementAllocation    allocationCounter = "preparedStmt"
-	extractedStatementsAllocation  allocationCounter = "extractedStmts"
-	pendingResultAllocation        allocationCounter = "pendingRes"
 	appenderAllocation             allocationCounter = "appender"
-	tableDescriptionAllocation     allocationCounter = "tableDesc"
+	arrowAllocation                allocationCounter = "arrow"
+	arrowConvertedSchemaAllocation allocationCounter = "arrowConvertedSchema"
+	arrowOptionsAllocation         allocationCounter = "arrowOptions"
+	bigNumAllocation               allocationCounter = "bigNum"
+	bitAllocation                  allocationCounter = "bit"
+	blobAllocation                 allocationCounter = "blob"
+	clientContextAllocation        allocationCounter = "ctx"
 	configAllocation               allocationCounter = "config"
-	logicalTypeAllocation          allocationCounter = "logicalType"
+	connectionAllocation           allocationCounter = "conn"
 	dataChunkAllocation            allocationCounter = "chunk"
-	valueAllocation                allocationCounter = "v"
+	databaseAllocation             allocationCounter = "db"
 	errorDataAllocation            allocationCounter = "errorData"
 	expressionAllocation           allocationCounter = "expr"
+	extractedStatementsAllocation  allocationCounter = "extractedStmts"
+	instanceCacheAllocation        allocationCounter = "cache"
+	logicalTypeAllocation          allocationCounter = "logicalType"
+	logStorageAllocation           allocationCounter = "logStorage"
+	pendingResultAllocation        allocationCounter = "pendingRes"
+	preparedStatementAllocation    allocationCounter = "preparedStmt"
+	resultAllocation               allocationCounter = "res"
 	scalarFunctionAllocation       allocationCounter = "scalarFunc"
 	scalarFunctionSetAllocation    allocationCounter = "scalarFuncSet"
+	selectionVectorAllocation      allocationCounter = "sel"
+	tableDescriptionAllocation     allocationCounter = "tableDesc"
 	tableFunctionAllocation        allocationCounter = "tableFunc"
-	arrowAllocation                allocationCounter = "arrow"
-	arrowOptionsAllocation         allocationCounter = "arrowOptions"
-	arrowConvertedSchemaAllocation allocationCounter = "arrowConvertedSchema"
-	logStorageAllocation           allocationCounter = "logStorage"
-	blobAllocation                 allocationCounter = "blob"
-	bitAllocation                  allocationCounter = "bit"
-	bigNumAllocation               allocationCounter = "bigNum"
-	resultAllocation               allocationCounter = "res"
+	valueAllocation                allocationCounter = "v"
+	vectorAllocation               allocationCounter = "vec"
 )
 
 // AllocationCounter* constants are stable keys for GetAllocationCount.
 // Prefer these constants over hard-coded counter strings.
 const (
-	AllocationCounterVector               = string(vectorAllocation)
-	AllocationCounterSelectionVector      = string(selectionVectorAllocation)
-	AllocationCounterInstanceCache        = string(instanceCacheAllocation)
-	AllocationCounterDatabase             = string(databaseAllocation)
-	AllocationCounterConnection           = string(connectionAllocation)
-	AllocationCounterClientContext        = string(clientContextAllocation)
-	AllocationCounterPreparedStatement    = string(preparedStatementAllocation)
-	AllocationCounterExtractedStatements  = string(extractedStatementsAllocation)
-	AllocationCounterPendingResult        = string(pendingResultAllocation)
 	AllocationCounterAppender             = string(appenderAllocation)
-	AllocationCounterTableDescription     = string(tableDescriptionAllocation)
+	AllocationCounterArrow                = string(arrowAllocation)
+	AllocationCounterArrowConvertedSchema = string(arrowConvertedSchemaAllocation)
+	AllocationCounterArrowOptions         = string(arrowOptionsAllocation)
+	AllocationCounterBigNum               = string(bigNumAllocation)
+	AllocationCounterBit                  = string(bitAllocation)
+	AllocationCounterBlob                 = string(blobAllocation)
+	AllocationCounterClientContext        = string(clientContextAllocation)
 	AllocationCounterConfig               = string(configAllocation)
-	AllocationCounterLogicalType          = string(logicalTypeAllocation)
+	AllocationCounterConnection           = string(connectionAllocation)
 	AllocationCounterDataChunk            = string(dataChunkAllocation)
-	AllocationCounterValue                = string(valueAllocation)
+	AllocationCounterDatabase             = string(databaseAllocation)
 	AllocationCounterErrorData            = string(errorDataAllocation)
 	AllocationCounterExpression           = string(expressionAllocation)
+	AllocationCounterExtractedStatements  = string(extractedStatementsAllocation)
+	AllocationCounterInstanceCache        = string(instanceCacheAllocation)
+	AllocationCounterLogicalType          = string(logicalTypeAllocation)
+	AllocationCounterLogStorage           = string(logStorageAllocation)
+	AllocationCounterPendingResult        = string(pendingResultAllocation)
+	AllocationCounterPreparedStatement    = string(preparedStatementAllocation)
+	AllocationCounterResult               = string(resultAllocation)
 	AllocationCounterScalarFunction       = string(scalarFunctionAllocation)
 	AllocationCounterScalarFunctionSet    = string(scalarFunctionSetAllocation)
+	AllocationCounterSelectionVector      = string(selectionVectorAllocation)
+	AllocationCounterTableDescription     = string(tableDescriptionAllocation)
 	AllocationCounterTableFunction        = string(tableFunctionAllocation)
-	AllocationCounterArrow                = string(arrowAllocation)
-	AllocationCounterArrowOptions         = string(arrowOptionsAllocation)
-	AllocationCounterArrowConvertedSchema = string(arrowConvertedSchemaAllocation)
-	AllocationCounterLogStorage           = string(logStorageAllocation)
-	AllocationCounterBlob                 = string(blobAllocation)
-	AllocationCounterBit                  = string(bitAllocation)
-	AllocationCounterBigNum               = string(bigNumAllocation)
-	AllocationCounterResult               = string(resultAllocation)
+	AllocationCounterValue                = string(valueAllocation)
+	AllocationCounterVector               = string(vectorAllocation)
 )
 
 func trackAllocation(counter allocationCounter, ptr unsafe.Pointer) {

--- a/alloc.go
+++ b/alloc.go
@@ -11,6 +11,7 @@ import "C"
 import (
 	"fmt"
 	"log"
+	"sort"
 	"sync"
 	"unsafe"
 )
@@ -118,43 +119,122 @@ func allocNames(names []string) nameListAlloc {
 
 var allocCounts syncMap
 
-type syncMap struct {
-	lock sync.Mutex
-	m    map[string]int
+type allocationCounter string
+
+const (
+	vectorAllocation               allocationCounter = "vec"
+	selectionVectorAllocation      allocationCounter = "sel"
+	instanceCacheAllocation        allocationCounter = "cache"
+	databaseAllocation             allocationCounter = "db"
+	connectionAllocation           allocationCounter = "conn"
+	clientContextAllocation        allocationCounter = "ctx"
+	preparedStatementAllocation    allocationCounter = "preparedStmt"
+	extractedStatementsAllocation  allocationCounter = "extractedStmts"
+	pendingResultAllocation        allocationCounter = "pendingRes"
+	appenderAllocation             allocationCounter = "appender"
+	tableDescriptionAllocation     allocationCounter = "tableDesc"
+	configAllocation               allocationCounter = "config"
+	logicalTypeAllocation          allocationCounter = "logicalType"
+	dataChunkAllocation            allocationCounter = "chunk"
+	valueAllocation                allocationCounter = "v"
+	errorDataAllocation            allocationCounter = "errorData"
+	expressionAllocation           allocationCounter = "expr"
+	scalarFunctionAllocation       allocationCounter = "scalarFunc"
+	scalarFunctionSetAllocation    allocationCounter = "scalarFuncSet"
+	tableFunctionAllocation        allocationCounter = "tableFunc"
+	arrowAllocation                allocationCounter = "arrow"
+	arrowOptionsAllocation         allocationCounter = "arrowOptions"
+	arrowConvertedSchemaAllocation allocationCounter = "arrowConvertedSchema"
+	logStorageAllocation           allocationCounter = "logStorage"
+	blobAllocation                 allocationCounter = "blob"
+	bitAllocation                  allocationCounter = "bit"
+	bigNumAllocation               allocationCounter = "bigNum"
+	resultAllocation               allocationCounter = "res"
+)
+
+// AllocationCounter* constants are stable keys for GetAllocationCount.
+// Prefer these constants over hard-coded counter strings.
+const (
+	AllocationCounterVector               = string(vectorAllocation)
+	AllocationCounterSelectionVector      = string(selectionVectorAllocation)
+	AllocationCounterInstanceCache        = string(instanceCacheAllocation)
+	AllocationCounterDatabase             = string(databaseAllocation)
+	AllocationCounterConnection           = string(connectionAllocation)
+	AllocationCounterClientContext        = string(clientContextAllocation)
+	AllocationCounterPreparedStatement    = string(preparedStatementAllocation)
+	AllocationCounterExtractedStatements  = string(extractedStatementsAllocation)
+	AllocationCounterPendingResult        = string(pendingResultAllocation)
+	AllocationCounterAppender             = string(appenderAllocation)
+	AllocationCounterTableDescription     = string(tableDescriptionAllocation)
+	AllocationCounterConfig               = string(configAllocation)
+	AllocationCounterLogicalType          = string(logicalTypeAllocation)
+	AllocationCounterDataChunk            = string(dataChunkAllocation)
+	AllocationCounterValue                = string(valueAllocation)
+	AllocationCounterErrorData            = string(errorDataAllocation)
+	AllocationCounterExpression           = string(expressionAllocation)
+	AllocationCounterScalarFunction       = string(scalarFunctionAllocation)
+	AllocationCounterScalarFunctionSet    = string(scalarFunctionSetAllocation)
+	AllocationCounterTableFunction        = string(tableFunctionAllocation)
+	AllocationCounterArrow                = string(arrowAllocation)
+	AllocationCounterArrowOptions         = string(arrowOptionsAllocation)
+	AllocationCounterArrowConvertedSchema = string(arrowConvertedSchemaAllocation)
+	AllocationCounterLogStorage           = string(logStorageAllocation)
+	AllocationCounterBlob                 = string(blobAllocation)
+	AllocationCounterBit                  = string(bitAllocation)
+	AllocationCounterBigNum               = string(bigNumAllocation)
+	AllocationCounterResult               = string(resultAllocation)
+)
+
+func trackAllocation(counter allocationCounter, ptr unsafe.Pointer) {
+	if debugMode && ptr != nil {
+		incrAllocationCount(counter)
+	}
 }
 
-func incrAllocCount(k string) {
+func releaseAllocation(counter allocationCounter, ptr unsafe.Pointer) {
+	if debugMode && ptr != nil {
+		decrAllocationCount(counter)
+	}
+}
+
+func incrAllocationCount(counter allocationCounter) {
 	allocCounts.lock.Lock()
 	defer allocCounts.lock.Unlock()
 
 	if allocCounts.m == nil {
-		allocCounts.m = make(map[string]int)
+		allocCounts.m = make(map[allocationCounter]int)
 	}
 
-	allocCounts.m[k]++
+	allocCounts.m[counter]++
 }
 
-func decrAllocCount(k string) {
+func decrAllocationCount(counter allocationCounter) {
 	allocCounts.lock.Lock()
 	defer allocCounts.lock.Unlock()
 
 	if allocCounts.m == nil {
-		allocCounts.m = make(map[string]int)
+		return
 	}
 
-	if v, ok := allocCounts.m[k]; ok {
+	if v, ok := allocCounts.m[counter]; ok {
 		if v == 1 {
-			delete(allocCounts.m, k)
+			delete(allocCounts.m, counter)
 			return
 		}
-		allocCounts.m[k]--
+		allocCounts.m[counter]--
 	}
+}
+
+type syncMap struct {
+	lock sync.Mutex
+	m    map[allocationCounter]int
 }
 
 // VerifyAllocationCounters verifies all allocation counters.
 // This includes the instance cache, which should be kept alive as long as the application is kept alive,
 // causing this verification to fail.
-// If you're using the instance cache, use VerifyAllocationCounter instead.
+// If you're using the instance cache, use GetAllocationCount with
+// AllocationCounterInstanceCache to account for it explicitly.
 func VerifyAllocationCounters() {
 	msg := GetAllocationCounts()
 	if msg != "" {
@@ -163,7 +243,8 @@ func VerifyAllocationCounters() {
 }
 
 // GetAllocationCount returns the value of an allocation count, and true,
-// if it exists, otherwise zero, and false.
+// if it exists, otherwise zero, and false. Use the AllocationCounter*
+// constants instead of hard-coded strings.
 func GetAllocationCount(k string) (int, bool) {
 	allocCounts.lock.Lock()
 	defer allocCounts.lock.Unlock()
@@ -172,7 +253,7 @@ func GetAllocationCount(k string) (int, bool) {
 		return 0, false
 	}
 
-	v, ok := allocCounts.m[k]
+	v, ok := allocCounts.m[allocationCounter(k)]
 	return v, ok
 }
 
@@ -185,12 +266,17 @@ func GetAllocationCounts() string {
 		return ""
 	}
 
-	msg := ""
-	if len(allocCounts.m) != 0 {
-		for k, v := range allocCounts.m {
-			msg += fmt.Sprintf("%s count is %d\n", k, v)
-		}
+	keys := make([]allocationCounter, 0, len(allocCounts.m))
+	for counter := range allocCounts.m {
+		keys = append(keys, counter)
 	}
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i] < keys[j]
+	})
 
+	msg := ""
+	for _, k := range keys {
+		msg += fmt.Sprintf("%s count is %d\n", k, allocCounts.m[k])
+	}
 	return msg
 }

--- a/alloc_test.go
+++ b/alloc_test.go
@@ -1,0 +1,107 @@
+package duckdb_go_bindings
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func withIsolatedAllocationCounts(t *testing.T) {
+	t.Helper()
+
+	allocCounts.lock.Lock()
+	previous := allocCounts.m
+	allocCounts.m = nil
+	allocCounts.lock.Unlock()
+
+	t.Cleanup(func() {
+		allocCounts.lock.Lock()
+		allocCounts.m = previous
+		allocCounts.lock.Unlock()
+	})
+}
+
+func TestAllocationCountersUseStablePublicKeys(t *testing.T) {
+	withIsolatedAllocationCounts(t)
+
+	incrAllocationCount(valueAllocation)
+	incrAllocationCount(databaseAllocation)
+
+	got, ok := GetAllocationCount(AllocationCounterValue)
+	if !ok || got != 1 {
+		t.Fatalf("GetAllocationCount(%q) = %d, %t; want 1, true", AllocationCounterValue, got, ok)
+	}
+
+	got, ok = GetAllocationCount(AllocationCounterDatabase)
+	if !ok || got != 1 {
+		t.Fatalf("GetAllocationCount(%q) = %d, %t; want 1, true", AllocationCounterDatabase, got, ok)
+	}
+
+	got, ok = GetAllocationCount("value")
+	if ok || got != 0 {
+		t.Fatalf("GetAllocationCount(\"value\") = %d, %t; want 0, false", got, ok)
+	}
+
+	const want = "db count is 1\nv count is 1\n"
+	if got := GetAllocationCounts(); got != want {
+		t.Fatalf("GetAllocationCounts() = %q; want %q", got, want)
+	}
+}
+
+func TestDecrAllocationCountAbsentIsNoOp(t *testing.T) {
+	withIsolatedAllocationCounts(t)
+
+	decrAllocationCount(valueAllocation)
+	if got := GetAllocationCounts(); got != "" {
+		t.Fatalf("GetAllocationCounts() after absent decrement = %q; want empty", got)
+	}
+
+	incrAllocationCount(valueAllocation)
+	decrAllocationCount(valueAllocation)
+	decrAllocationCount(valueAllocation)
+
+	got, ok := GetAllocationCount(AllocationCounterValue)
+	if ok || got != 0 {
+		t.Fatalf("GetAllocationCount(%q) after double decrement = %d, %t; want 0, false", AllocationCounterValue, got, ok)
+	}
+}
+
+func TestTrackAllocationHonorsDebugMode(t *testing.T) {
+	withIsolatedAllocationCounts(t)
+
+	var marker byte
+	trackAllocation(valueAllocation, unsafe.Pointer(&marker))
+
+	got, ok := GetAllocationCount(AllocationCounterValue)
+	if debugMode {
+		if !ok || got != 1 {
+			t.Fatalf("GetAllocationCount(%q) = %d, %t; want 1, true", AllocationCounterValue, got, ok)
+		}
+		return
+	}
+
+	if ok || got != 0 {
+		t.Fatalf("GetAllocationCount(%q) = %d, %t; want 0, false", AllocationCounterValue, got, ok)
+	}
+}
+
+func TestTrackAllocationIgnoresNilPointer(t *testing.T) {
+	withIsolatedAllocationCounts(t)
+
+	trackAllocation(valueAllocation, nil)
+
+	got, ok := GetAllocationCount(AllocationCounterValue)
+	if ok || got != 0 {
+		t.Fatalf("GetAllocationCount(%q) = %d, %t; want 0, false", AllocationCounterValue, got, ok)
+	}
+}
+
+func TestTrackedResultIgnoresEmptyResult(t *testing.T) {
+	withIsolatedAllocationCounts(t)
+
+	trackedResult(&Result{})
+
+	got, ok := GetAllocationCount(AllocationCounterResult)
+	if ok || got != 0 {
+		t.Fatalf("GetAllocationCount(%q) = %d, %t; want 0, false", AllocationCounterResult, got, ok)
+	}
+}

--- a/alloc_test.go
+++ b/alloc_test.go
@@ -3,6 +3,8 @@ package duckdb_go_bindings
 import (
 	"testing"
 	"unsafe"
+
+	"github.com/stretchr/testify/require"
 )
 
 func withIsolatedAllocationCounts(t *testing.T) {
@@ -27,42 +29,34 @@ func TestAllocationCountersUseStablePublicKeys(t *testing.T) {
 	incrAllocationCount(databaseAllocation)
 
 	got, ok := GetAllocationCount(AllocationCounterValue)
-	if !ok || got != 1 {
-		t.Fatalf("GetAllocationCount(%q) = %d, %t; want 1, true", AllocationCounterValue, got, ok)
-	}
+	require.True(t, ok)
+	require.Equal(t, 1, got)
 
 	got, ok = GetAllocationCount(AllocationCounterDatabase)
-	if !ok || got != 1 {
-		t.Fatalf("GetAllocationCount(%q) = %d, %t; want 1, true", AllocationCounterDatabase, got, ok)
-	}
+	require.True(t, ok)
+	require.Equal(t, 1, got)
 
 	got, ok = GetAllocationCount("value")
-	if ok || got != 0 {
-		t.Fatalf("GetAllocationCount(\"value\") = %d, %t; want 0, false", got, ok)
-	}
+	require.False(t, ok)
+	require.Zero(t, got)
 
 	const want = "db count is 1\nv count is 1\n"
-	if got := GetAllocationCounts(); got != want {
-		t.Fatalf("GetAllocationCounts() = %q; want %q", got, want)
-	}
+	require.Equal(t, want, GetAllocationCounts())
 }
 
 func TestDecrAllocationCountAbsentIsNoOp(t *testing.T) {
 	withIsolatedAllocationCounts(t)
 
 	decrAllocationCount(valueAllocation)
-	if got := GetAllocationCounts(); got != "" {
-		t.Fatalf("GetAllocationCounts() after absent decrement = %q; want empty", got)
-	}
+	require.Empty(t, GetAllocationCounts())
 
 	incrAllocationCount(valueAllocation)
 	decrAllocationCount(valueAllocation)
 	decrAllocationCount(valueAllocation)
 
 	got, ok := GetAllocationCount(AllocationCounterValue)
-	if ok || got != 0 {
-		t.Fatalf("GetAllocationCount(%q) after double decrement = %d, %t; want 0, false", AllocationCounterValue, got, ok)
-	}
+	require.False(t, ok)
+	require.Zero(t, got)
 }
 
 func TestTrackAllocationHonorsDebugMode(t *testing.T) {
@@ -73,15 +67,13 @@ func TestTrackAllocationHonorsDebugMode(t *testing.T) {
 
 	got, ok := GetAllocationCount(AllocationCounterValue)
 	if debugMode {
-		if !ok || got != 1 {
-			t.Fatalf("GetAllocationCount(%q) = %d, %t; want 1, true", AllocationCounterValue, got, ok)
-		}
+		require.True(t, ok)
+		require.Equal(t, 1, got)
 		return
 	}
 
-	if ok || got != 0 {
-		t.Fatalf("GetAllocationCount(%q) = %d, %t; want 0, false", AllocationCounterValue, got, ok)
-	}
+	require.False(t, ok)
+	require.Zero(t, got)
 }
 
 func TestTrackAllocationIgnoresNilPointer(t *testing.T) {
@@ -90,9 +82,8 @@ func TestTrackAllocationIgnoresNilPointer(t *testing.T) {
 	trackAllocation(valueAllocation, nil)
 
 	got, ok := GetAllocationCount(AllocationCounterValue)
-	if ok || got != 0 {
-		t.Fatalf("GetAllocationCount(%q) = %d, %t; want 0, false", AllocationCounterValue, got, ok)
-	}
+	require.False(t, ok)
+	require.Zero(t, got)
 }
 
 func TestTrackedResultIgnoresEmptyResult(t *testing.T) {
@@ -101,7 +92,6 @@ func TestTrackedResultIgnoresEmptyResult(t *testing.T) {
 	trackedResult(&Result{})
 
 	got, ok := GetAllocationCount(AllocationCounterResult)
-	if ok || got != 0 {
-		t.Fatalf("GetAllocationCount(%q) = %d, %t; want 0, false", AllocationCounterResult, got, ok)
-	}
+	require.False(t, ok)
+	require.Zero(t, got)
 }

--- a/alloc_test.go
+++ b/alloc_test.go
@@ -10,6 +10,8 @@ import (
 func withIsolatedAllocationCounts(t *testing.T) {
 	t.Helper()
 
+	// Tests using this helper must stay serial: it swaps package-global
+	// allocation state while the test is running.
 	allocCounts.lock.Lock()
 	previous := allocCounts.m
 	allocCounts.m = nil

--- a/appender.go
+++ b/appender.go
@@ -21,10 +21,7 @@ func AppenderCreate(conn Connection, schema string, table string, outAppender *A
 
 	var appender C.duckdb_appender
 	state := C.duckdb_appender_create(conn.data(), cSchema, cTable, &appender)
-	outAppender.Ptr = unsafe.Pointer(appender)
-	if debugMode {
-		incrAllocCount("appender")
-	}
+	*outAppender = trackedAppender(appender)
 	return state
 }
 
@@ -40,10 +37,7 @@ func AppenderCreateExt(conn Connection, catalog string, schema string, table str
 
 	var appender C.duckdb_appender
 	state := C.duckdb_appender_create_ext(conn.data(), cCatalog, cSchema, cTable, &appender)
-	outAppender.Ptr = unsafe.Pointer(appender)
-	if debugMode {
-		incrAllocCount("appender")
-	}
+	*outAppender = trackedAppender(appender)
 	return state
 }
 
@@ -69,10 +63,7 @@ func AppenderCreateQuery(conn Connection, query string, types []LogicalType, tab
 	columnCount := IdxT(len(types))
 	var appender C.duckdb_appender
 	state := C.duckdb_appender_create_query(conn.data(), cQuery, columnCount, typesPtr, (*C.char)(cTableName), namesAlloc.arr, &appender)
-	outAppender.Ptr = unsafe.Pointer(appender)
-	if debugMode {
-		incrAllocCount("appender")
-	}
+	*outAppender = trackedAppender(appender)
 	return state
 }
 
@@ -84,12 +75,7 @@ func AppenderColumnCount(appender Appender) IdxT {
 // The return value must be destroyed with DestroyLogicalType.
 func AppenderColumnType(appender Appender, index IdxT) LogicalType {
 	logicalType := C.duckdb_appender_column_type(appender.data(), index)
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(logicalType),
-	}
+	return trackedLogicalType(logicalType)
 }
 
 func AppenderError(appender Appender) string {
@@ -101,12 +87,7 @@ func AppenderError(appender Appender) string {
 // The return value must be destroyed with DestroyErrorData.
 func AppenderErrorData(appender Appender) ErrorData {
 	errorData := C.duckdb_appender_error_data(appender.data())
-	if debugMode {
-		incrAllocCount("errorData")
-	}
-	return ErrorData{
-		Ptr: unsafe.Pointer(errorData),
-	}
+	return trackedErrorData(errorData)
 }
 
 func AppenderFlush(appender Appender) State {
@@ -126,9 +107,7 @@ func AppenderDestroy(appender *Appender) State {
 	if appender.Ptr == nil {
 		return StateSuccess
 	}
-	if debugMode {
-		decrAllocCount("appender")
-	}
+	releaseAllocation(appenderAllocation, appender.Ptr)
 	data := appender.data()
 	state := C.duckdb_appender_destroy(&data)
 	appender.Ptr = nil

--- a/arrow.go
+++ b/arrow.go
@@ -83,10 +83,7 @@ func NewArrowSchema(options ArrowOptions, types []LogicalType, names []string) (
 	}()
 
 	ed := C.duckdb_to_arrow_schema(options.data(), cTypes, cNames.arr, C.idx_t(len(names)), (*C.struct_ArrowSchema)(arr))
-	errData := ErrorData{Ptr: unsafe.Pointer(ed)}
-	if debugMode && ed != nil {
-		incrAllocCount("errorData")
-	}
+	errData := trackedErrorData(ed)
 	if ErrorDataHasError(errData) {
 		return nil, errData
 	}
@@ -108,10 +105,7 @@ func DataChunkToArrowArray(options ArrowOptions, schema *arrow.Schema, chunk Dat
 	}()
 
 	ed := C.duckdb_data_chunk_to_arrow(options.data(), chunk.data(), (*C.struct_ArrowArray)(arr))
-	errData := ErrorData{Ptr: unsafe.Pointer(ed)}
-	if debugMode && ed != nil {
-		incrAllocCount("errorData")
-	}
+	errData := trackedErrorData(ed)
 	if ErrorDataHasError(errData) {
 		return nil, errData
 	}
@@ -135,14 +129,8 @@ func SchemaFromArrow(conn Connection, schema *arrow.Schema) (ArrowConvertedSchem
 
 	var convertedSchema C.duckdb_arrow_converted_schema
 	ed := C.duckdb_schema_from_arrow(conn.data(), (*C.struct_ArrowSchema)(arr), &convertedSchema)
-	errData := ErrorData{Ptr: unsafe.Pointer(ed)}
-	if debugMode && ed != nil {
-		incrAllocCount("errorData")
-	}
-	if debugMode && convertedSchema != nil {
-		incrAllocCount("arrowConvertedSchema")
-	}
-	return ArrowConvertedSchema{Ptr: unsafe.Pointer(convertedSchema)}, errData
+	errData := trackedErrorData(ed)
+	return trackedArrowConvertedSchema(convertedSchema), errData
 }
 
 // DataChunkFromArrow converts an Arrow RecordBatch to a DuckDB DataChunk using the provided Connection and ArrowConvertedSchema.
@@ -163,14 +151,8 @@ func DataChunkFromArrow(conn Connection, rec arrow.RecordBatch, schema ArrowConv
 
 	var chunk C.duckdb_data_chunk
 	ed := C.duckdb_data_chunk_from_arrow(conn.data(), (*C.struct_ArrowArray)(arr), schema.data(), &chunk)
-	errData := ErrorData{Ptr: unsafe.Pointer(ed)}
-	if debugMode && ed != nil {
-		incrAllocCount("errorData")
-	}
-	if debugMode && chunk != nil {
-		incrAllocCount("chunk")
-	}
-	return DataChunk{Ptr: unsafe.Pointer(chunk)}, errData
+	errData := trackedErrorData(ed)
+	return trackedDataChunk(chunk), errData
 }
 
 // DestroyArrowConvertedSchema wraps duckdb_destroy_arrow_converted_schema.
@@ -178,9 +160,7 @@ func DestroyArrowConvertedSchema(schema *ArrowConvertedSchema) {
 	if schema.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("arrowConvertedSchema")
-	}
+	releaseAllocation(arrowConvertedSchemaAllocation, schema.Ptr)
 	data := schema.data()
 	C.duckdb_destroy_arrow_converted_schema(&data)
 	schema.Ptr = nil
@@ -213,9 +193,7 @@ func DestroyArrow(arrow *Arrow) {
 	if arrow.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("arrow")
-	}
+	releaseAllocation(arrowAllocation, arrow.Ptr)
 	data := arrow.data()
 	C.duckdb_destroy_arrow(&data)
 	arrow.Ptr = nil
@@ -227,10 +205,7 @@ func DestroyArrow(arrow *Arrow) {
 func ExecutePreparedArrow(preparedStmt PreparedStatement, outArrow *Arrow) State {
 	var arrow C.duckdb_arrow
 	state := C.duckdb_execute_prepared_arrow(preparedStmt.data(), &arrow)
-	outArrow.Ptr = unsafe.Pointer(arrow)
-	if debugMode {
-		incrAllocCount("arrow")
-	}
+	*outArrow = trackedArrow(arrow)
 	return state
 }
 

--- a/config.go
+++ b/config.go
@@ -15,10 +15,7 @@ import "unsafe"
 func CreateConfig(outConfig *Config) State {
 	var config C.duckdb_config
 	state := C.duckdb_create_config(&config)
-	outConfig.Ptr = unsafe.Pointer(config)
-	if debugMode {
-		incrAllocCount("config")
-	}
+	*outConfig = trackedConfig(config)
 	return state
 }
 
@@ -49,9 +46,7 @@ func DestroyConfig(config *Config) {
 	if config.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("config")
-	}
+	releaseAllocation(configAllocation, config.Ptr)
 	data := config.data()
 	C.duckdb_destroy_config(&data)
 	config.Ptr = nil

--- a/connection.go
+++ b/connection.go
@@ -14,12 +14,7 @@ import "unsafe"
 // The return value must be destroyed with DestroyInstanceCache.
 func CreateInstanceCache() InstanceCache {
 	cache := C.duckdb_create_instance_cache()
-	if debugMode {
-		incrAllocCount("cache")
-	}
-	return InstanceCache{
-		Ptr: unsafe.Pointer(cache),
-	}
+	return trackedInstanceCache(cache)
 }
 
 // GetOrCreateFromCache wraps duckdb_get_or_create_from_cache.
@@ -32,12 +27,8 @@ func GetOrCreateFromCache(cache InstanceCache, path string, outDb *Database, con
 
 	var db C.duckdb_database
 	state := C.duckdb_get_or_create_from_cache(cache.data(), cPath, &db, config.data(), &err)
-	outDb.Ptr = unsafe.Pointer(db)
+	*outDb = trackedDatabase(db)
 	*errMsg = C.GoString(err)
-
-	if debugMode {
-		incrAllocCount("db")
-	}
 	return state
 }
 
@@ -46,9 +37,7 @@ func DestroyInstanceCache(cache *InstanceCache) {
 	if cache.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("cache")
-	}
+	releaseAllocation(instanceCacheAllocation, cache.Ptr)
 	data := cache.data()
 	C.duckdb_destroy_instance_cache(&data)
 	cache.Ptr = nil
@@ -63,11 +52,7 @@ func Open(path string, outDb *Database) State {
 
 	var db C.duckdb_database
 	state := C.duckdb_open(cPath, &db)
-	outDb.Ptr = unsafe.Pointer(db)
-
-	if debugMode {
-		incrAllocCount("db")
-	}
+	*outDb = trackedDatabase(db)
 	return state
 }
 
@@ -81,12 +66,8 @@ func OpenExt(path string, outDb *Database, config Config, errMsg *string) State 
 
 	var db C.duckdb_database
 	state := C.duckdb_open_ext(cPath, &db, config.data(), &err)
-	outDb.Ptr = unsafe.Pointer(db)
+	*outDb = trackedDatabase(db)
 	*errMsg = C.GoString(err)
-
-	if debugMode {
-		incrAllocCount("db")
-	}
 	return state
 }
 
@@ -95,9 +76,7 @@ func Close(db *Database) {
 	if db.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("db")
-	}
+	releaseAllocation(databaseAllocation, db.Ptr)
 	data := db.data()
 	C.duckdb_close(&data)
 	db.Ptr = nil
@@ -108,10 +87,7 @@ func Close(db *Database) {
 func Connect(db Database, outConn *Connection) State {
 	var conn C.duckdb_connection
 	state := C.duckdb_connect(db.data(), &conn)
-	outConn.Ptr = unsafe.Pointer(conn)
-	if debugMode {
-		incrAllocCount("conn")
-	}
+	*outConn = trackedConnection(conn)
 	return state
 }
 
@@ -128,9 +104,7 @@ func Disconnect(conn *Connection) {
 	if conn.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("conn")
-	}
+	releaseAllocation(connectionAllocation, conn.Ptr)
 	data := conn.data()
 	C.duckdb_disconnect(&data)
 	conn.Ptr = nil
@@ -141,10 +115,7 @@ func Disconnect(conn *Connection) {
 func ConnectionGetClientContext(conn Connection, outCtx *ClientContext) {
 	var ctx C.duckdb_client_context
 	C.duckdb_connection_get_client_context(conn.data(), &ctx)
-	outCtx.Ptr = unsafe.Pointer(ctx)
-	if debugMode {
-		incrAllocCount("ctx")
-	}
+	*outCtx = trackedClientContext(ctx)
 }
 
 // ConnectionGetArrowOptions wraps duckdb_connection_get_arrow_options.
@@ -152,10 +123,7 @@ func ConnectionGetClientContext(conn Connection, outCtx *ClientContext) {
 func ConnectionGetArrowOptions(conn Connection, outOptions *ArrowOptions) {
 	var options C.duckdb_arrow_options
 	C.duckdb_connection_get_arrow_options(conn.data(), &options)
-	outOptions.Ptr = unsafe.Pointer(options)
-	if debugMode {
-		incrAllocCount("arrowOptions")
-	}
+	*outOptions = trackedArrowOptions(options)
 }
 
 func ClientContextGetConnectionId(ctx ClientContext) IdxT {
@@ -167,9 +135,7 @@ func DestroyClientContext(ctx *ClientContext) {
 	if ctx.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("ctx")
-	}
+	releaseAllocation(clientContextAllocation, ctx.Ptr)
 	data := ctx.data()
 	C.duckdb_destroy_client_context(&data)
 	ctx.Ptr = nil
@@ -180,9 +146,7 @@ func DestroyArrowOptions(options *ArrowOptions) {
 	if options.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("arrowOptions")
-	}
+	releaseAllocation(arrowOptionsAllocation, options.Ptr)
 	data := options.data()
 	C.duckdb_destroy_arrow_options(&data)
 	options.Ptr = nil
@@ -199,10 +163,5 @@ func GetTableNames(conn Connection, query string, qualified bool) Value {
 	cQuery := C.CString(query)
 	defer Free(unsafe.Pointer(cQuery))
 	v := C.duckdb_get_table_names(conn.data(), cQuery, C.bool(qualified))
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }

--- a/data_chunk.go
+++ b/data_chunk.go
@@ -17,13 +17,8 @@ func CreateDataChunk(types []LogicalType) DataChunk {
 	defer Free(unsafe.Pointer(typesPtr))
 
 	chunk := C.duckdb_create_data_chunk(typesPtr, IdxT(len(types)))
-	if debugMode {
-		incrAllocCount("chunk")
-	}
 
-	return DataChunk{
-		Ptr: unsafe.Pointer(chunk),
-	}
+	return trackedDataChunk(chunk)
 }
 
 // DestroyDataChunk wraps duckdb_destroy_data_chunk.
@@ -31,9 +26,7 @@ func DestroyDataChunk(chunk *DataChunk) {
 	if chunk.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("chunk")
-	}
+	releaseAllocation(dataChunkAllocation, chunk.Ptr)
 	data := chunk.data()
 	C.duckdb_destroy_data_chunk(&data)
 	chunk.Ptr = nil

--- a/errors.go
+++ b/errors.go
@@ -17,12 +17,7 @@ func CreateErrorData(t ErrorType, msg string) ErrorData {
 	defer Free(unsafe.Pointer(cMsg))
 
 	errorData := C.duckdb_create_error_data(t, cMsg)
-	if debugMode {
-		incrAllocCount("errorData")
-	}
-	return ErrorData{
-		Ptr: unsafe.Pointer(errorData),
-	}
+	return trackedErrorData(errorData)
 }
 
 // DestroyErrorData wraps duckdb_destroy_error_data.
@@ -30,9 +25,7 @@ func DestroyErrorData(errorData *ErrorData) {
 	if errorData.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("errorData")
-	}
+	releaseAllocation(errorDataAllocation, errorData.Ptr)
 	data := errorData.data()
 	C.duckdb_destroy_error_data(&data)
 	errorData.Ptr = nil

--- a/expression.go
+++ b/expression.go
@@ -8,16 +8,12 @@ package duckdb_go_bindings
 */
 import "C"
 
-import "unsafe"
-
 // DestroyExpression wraps duckdb_destroy_expression.
 func DestroyExpression(expr *Expression) {
 	if expr.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("expr")
-	}
+	releaseAllocation(expressionAllocation, expr.Ptr)
 	data := expr.data()
 	C.duckdb_destroy_expression(&data)
 	expr.Ptr = nil
@@ -27,12 +23,7 @@ func DestroyExpression(expr *Expression) {
 // The return value must be destroyed with DestroyLogicalType.
 func ExpressionReturnType(expr Expression) LogicalType {
 	logicalType := C.duckdb_expression_return_type(expr.data())
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(logicalType),
-	}
+	return trackedLogicalType(logicalType)
 }
 
 func ExpressionIsFoldable(expr Expression) bool {
@@ -45,12 +36,6 @@ func ExpressionIsFoldable(expr Expression) bool {
 func ExpressionFold(ctx ClientContext, expr Expression, outValue *Value) ErrorData {
 	var value C.duckdb_value
 	errorData := C.duckdb_expression_fold(ctx.data(), expr.data(), &value)
-	outValue.Ptr = unsafe.Pointer(value)
-	if debugMode {
-		incrAllocCount("v")
-		incrAllocCount("errorData")
-	}
-	return ErrorData{
-		Ptr: unsafe.Pointer(errorData),
-	}
+	*outValue = trackedValue(value)
+	return trackedErrorData(errorData)
 }

--- a/handles.go
+++ b/handles.go
@@ -41,6 +41,148 @@ import "unsafe"
 // TODO:
 // *duckdb_task_state
 
+func trackedVector(vec C.duckdb_vector) Vector {
+	trackAllocation(vectorAllocation, unsafe.Pointer(vec))
+	return Vector{Ptr: unsafe.Pointer(vec)}
+}
+
+func trackedSelectionVector(sel C.duckdb_selection_vector) SelectionVector {
+	trackAllocation(selectionVectorAllocation, unsafe.Pointer(sel))
+	return SelectionVector{Ptr: unsafe.Pointer(sel)}
+}
+
+func trackedInstanceCache(cache C.duckdb_instance_cache) InstanceCache {
+	trackAllocation(instanceCacheAllocation, unsafe.Pointer(cache))
+	return InstanceCache{Ptr: unsafe.Pointer(cache)}
+}
+
+func trackedDatabase(db C.duckdb_database) Database {
+	trackAllocation(databaseAllocation, unsafe.Pointer(db))
+	return Database{Ptr: unsafe.Pointer(db)}
+}
+
+func trackedConnection(conn C.duckdb_connection) Connection {
+	trackAllocation(connectionAllocation, unsafe.Pointer(conn))
+	return Connection{Ptr: unsafe.Pointer(conn)}
+}
+
+func trackedClientContext(ctx C.duckdb_client_context) ClientContext {
+	trackAllocation(clientContextAllocation, unsafe.Pointer(ctx))
+	return ClientContext{Ptr: unsafe.Pointer(ctx)}
+}
+
+func trackedPreparedStatement(preparedStmt C.duckdb_prepared_statement) PreparedStatement {
+	trackAllocation(preparedStatementAllocation, unsafe.Pointer(preparedStmt))
+	return PreparedStatement{Ptr: unsafe.Pointer(preparedStmt)}
+}
+
+func trackedExtractedStatements(extractedStmts C.duckdb_extracted_statements) ExtractedStatements {
+	trackAllocation(extractedStatementsAllocation, unsafe.Pointer(extractedStmts))
+	return ExtractedStatements{Ptr: unsafe.Pointer(extractedStmts)}
+}
+
+func trackedPendingResult(pendingRes C.duckdb_pending_result) PendingResult {
+	trackAllocation(pendingResultAllocation, unsafe.Pointer(pendingRes))
+	return PendingResult{Ptr: unsafe.Pointer(pendingRes)}
+}
+
+func trackedAppender(appender C.duckdb_appender) Appender {
+	trackAllocation(appenderAllocation, unsafe.Pointer(appender))
+	return Appender{Ptr: unsafe.Pointer(appender)}
+}
+
+func trackedTableDescription(description C.duckdb_table_description) TableDescription {
+	trackAllocation(tableDescriptionAllocation, unsafe.Pointer(description))
+	return TableDescription{Ptr: unsafe.Pointer(description)}
+}
+
+func trackedConfig(config C.duckdb_config) Config {
+	trackAllocation(configAllocation, unsafe.Pointer(config))
+	return Config{Ptr: unsafe.Pointer(config)}
+}
+
+func trackedLogicalType(logicalType C.duckdb_logical_type) LogicalType {
+	trackAllocation(logicalTypeAllocation, unsafe.Pointer(logicalType))
+	return LogicalType{Ptr: unsafe.Pointer(logicalType)}
+}
+
+func trackedDataChunk(chunk C.duckdb_data_chunk) DataChunk {
+	trackAllocation(dataChunkAllocation, unsafe.Pointer(chunk))
+	return DataChunk{Ptr: unsafe.Pointer(chunk)}
+}
+
+func trackedValue(v C.duckdb_value) Value {
+	trackAllocation(valueAllocation, unsafe.Pointer(v))
+	return Value{Ptr: unsafe.Pointer(v)}
+}
+
+func trackedResult(res *Result) {
+	if res == nil {
+		return
+	}
+	trackAllocation(resultAllocation, res.data.internal_data)
+}
+
+func trackedErrorData(errorData C.duckdb_error_data) ErrorData {
+	trackAllocation(errorDataAllocation, unsafe.Pointer(errorData))
+	return ErrorData{Ptr: unsafe.Pointer(errorData)}
+}
+
+func trackedBlob(blob Blob) Blob {
+	trackAllocation(blobAllocation, blob.data)
+	return blob
+}
+
+func trackedBit(bit Bit) Bit {
+	trackAllocation(bitAllocation, unsafe.Pointer(bit.data))
+	return bit
+}
+
+func trackedBigNum(bigNum BigNum) BigNum {
+	trackAllocation(bigNumAllocation, unsafe.Pointer(bigNum.data))
+	return bigNum
+}
+
+func trackedExpression(expr C.duckdb_expression) Expression {
+	trackAllocation(expressionAllocation, unsafe.Pointer(expr))
+	return Expression{Ptr: unsafe.Pointer(expr)}
+}
+
+func trackedScalarFunction(f C.duckdb_scalar_function) ScalarFunction {
+	trackAllocation(scalarFunctionAllocation, unsafe.Pointer(f))
+	return ScalarFunction{Ptr: unsafe.Pointer(f)}
+}
+
+func trackedScalarFunctionSet(set C.duckdb_scalar_function_set) ScalarFunctionSet {
+	trackAllocation(scalarFunctionSetAllocation, unsafe.Pointer(set))
+	return ScalarFunctionSet{Ptr: unsafe.Pointer(set)}
+}
+
+func trackedTableFunction(f C.duckdb_table_function) TableFunction {
+	trackAllocation(tableFunctionAllocation, unsafe.Pointer(f))
+	return TableFunction{Ptr: unsafe.Pointer(f)}
+}
+
+func trackedArrow(arrow C.duckdb_arrow) Arrow {
+	trackAllocation(arrowAllocation, unsafe.Pointer(arrow))
+	return Arrow{Ptr: unsafe.Pointer(arrow)}
+}
+
+func trackedArrowOptions(options C.duckdb_arrow_options) ArrowOptions {
+	trackAllocation(arrowOptionsAllocation, unsafe.Pointer(options))
+	return ArrowOptions{Ptr: unsafe.Pointer(options)}
+}
+
+func trackedArrowConvertedSchema(schema C.duckdb_arrow_converted_schema) ArrowConvertedSchema {
+	trackAllocation(arrowConvertedSchemaAllocation, unsafe.Pointer(schema))
+	return ArrowConvertedSchema{Ptr: unsafe.Pointer(schema)}
+}
+
+func trackedLogStorage(logStorage C.duckdb_log_storage) LogStorage {
+	trackAllocation(logStorageAllocation, unsafe.Pointer(logStorage))
+	return LogStorage{Ptr: unsafe.Pointer(logStorage)}
+}
+
 // Vector wraps *duckdb_vector.
 type Vector struct {
 	Ptr unsafe.Pointer

--- a/handles.go
+++ b/handles.go
@@ -36,7 +36,7 @@ import "unsafe"
 // the same somewhat mysterious runtime error as described for Result.
 // 'runtime error: cgo argument has Go pointer to unpinned Go pointer'.
 // See https://github.com/golang/go/issues/28606#issuecomment-2184269962.
-// When using a type alias, duckdb_result itself contains a Go unsafe.Pointer for its 'void *internal_ptr' field.
+// When using a type alias, duckdb_result itself contains a Go unsafe.Pointer for its 'void *internal_data' field.
 
 // TODO:
 // *duckdb_task_state

--- a/logging.go
+++ b/logging.go
@@ -14,12 +14,7 @@ import "unsafe"
 // The return value must be destroyed with DestroyLogStorage.
 func CreateLogStorage() LogStorage {
 	logStorage := C.duckdb_create_log_storage()
-	if debugMode {
-		incrAllocCount("logStorage")
-	}
-	return LogStorage{
-		Ptr: unsafe.Pointer(logStorage),
-	}
+	return trackedLogStorage(logStorage)
 }
 
 // DestroyLogStorage wraps duckdb_destroy_log_storage.
@@ -27,9 +22,7 @@ func DestroyLogStorage(logStorage *LogStorage) {
 	if logStorage.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("logStorage")
-	}
+	releaseAllocation(logStorageAllocation, logStorage.Ptr)
 	data := logStorage.data()
 	C.duckdb_destroy_log_storage(&data)
 	logStorage.Ptr = nil

--- a/logical_type.go
+++ b/logical_type.go
@@ -14,12 +14,7 @@ import "unsafe"
 // The return value must be destroyed with DestroyLogicalType.
 func CreateLogicalType(t Type) LogicalType {
 	logicalType := C.duckdb_create_logical_type(t)
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(logicalType),
-	}
+	return trackedLogicalType(logicalType)
 }
 
 func LogicalTypeGetAlias(logicalType LogicalType) string {
@@ -38,36 +33,21 @@ func LogicalTypeSetAlias(logicalType LogicalType, alias string) {
 // The return value must be destroyed with DestroyLogicalType.
 func CreateListType(child LogicalType) LogicalType {
 	logicalType := C.duckdb_create_list_type(child.data())
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(logicalType),
-	}
+	return trackedLogicalType(logicalType)
 }
 
 // CreateArrayType wraps duckdb_create_array_type.
 // The return value must be destroyed with DestroyLogicalType.
 func CreateArrayType(child LogicalType, size IdxT) LogicalType {
 	logicalType := C.duckdb_create_array_type(child.data(), size)
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(logicalType),
-	}
+	return trackedLogicalType(logicalType)
 }
 
 // CreateMapType wraps duckdb_create_map_type.
 // The return value must be destroyed with DestroyLogicalType.
 func CreateMapType(key LogicalType, value LogicalType) LogicalType {
 	logicalType := C.duckdb_create_map_type(key.data(), value.data())
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(logicalType),
-	}
+	return trackedLogicalType(logicalType)
 }
 
 // CreateUnionType wraps duckdb_create_union_type.
@@ -83,12 +63,7 @@ func CreateUnionType(types []LogicalType, names []string) LogicalType {
 	// Create the UNION type.
 	logicalType := C.duckdb_create_union_type(typesPtr, namesAlloc.arr, count)
 
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(logicalType),
-	}
+	return trackedLogicalType(logicalType)
 }
 
 // CreateStructType wraps duckdb_create_struct_type.
@@ -104,12 +79,7 @@ func CreateStructType(types []LogicalType, names []string) LogicalType {
 	// Create the STRUCT type.
 	logicalType := C.duckdb_create_struct_type(typesPtr, namesAlloc.arr, count)
 
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(logicalType),
-	}
+	return trackedLogicalType(logicalType)
 }
 
 // CreateEnumType wraps duckdb_create_enum_type.
@@ -122,24 +92,14 @@ func CreateEnumType(names []string) LogicalType {
 	// Create the ENUM type.
 	logicalType := C.duckdb_create_enum_type(namesAlloc.arr, count)
 
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(logicalType),
-	}
+	return trackedLogicalType(logicalType)
 }
 
 // CreateDecimalType wraps duckdb_create_decimal_type.
 // The return value must be destroyed with DestroyLogicalType.
 func CreateDecimalType(width uint8, scale uint8) LogicalType {
 	logicalType := C.duckdb_create_decimal_type(C.uint8_t(width), C.uint8_t(scale))
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(logicalType),
-	}
+	return trackedLogicalType(logicalType)
 }
 
 func GetTypeId(logicalType LogicalType) Type {
@@ -179,24 +139,14 @@ func EnumDictionaryValue(logicalType LogicalType, index IdxT) string {
 // The return value must be destroyed with DestroyLogicalType.
 func ListTypeChildType(logicalType LogicalType) LogicalType {
 	child := C.duckdb_list_type_child_type(logicalType.data())
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(child),
-	}
+	return trackedLogicalType(child)
 }
 
 // ArrayTypeChildType wraps duckdb_array_type_child_type.
 // The return value must be destroyed with DestroyLogicalType.
 func ArrayTypeChildType(logicalType LogicalType) LogicalType {
 	child := C.duckdb_array_type_child_type(logicalType.data())
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(child),
-	}
+	return trackedLogicalType(child)
 }
 
 func ArrayTypeArraySize(logicalType LogicalType) IdxT {
@@ -207,24 +157,14 @@ func ArrayTypeArraySize(logicalType LogicalType) IdxT {
 // The return value must be destroyed with DestroyLogicalType.
 func MapTypeKeyType(logicalType LogicalType) LogicalType {
 	key := C.duckdb_map_type_key_type(logicalType.data())
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(key),
-	}
+	return trackedLogicalType(key)
 }
 
 // MapTypeValueType wraps duckdb_map_type_value_type.
 // The return value must be destroyed with DestroyLogicalType.
 func MapTypeValueType(logicalType LogicalType) LogicalType {
 	value := C.duckdb_map_type_value_type(logicalType.data())
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(value),
-	}
+	return trackedLogicalType(value)
 }
 
 func StructTypeChildCount(logicalType LogicalType) IdxT {
@@ -241,12 +181,7 @@ func StructTypeChildName(logicalType LogicalType, index IdxT) string {
 // The return value must be destroyed with DestroyLogicalType.
 func StructTypeChildType(logicalType LogicalType, index IdxT) LogicalType {
 	child := C.duckdb_struct_type_child_type(logicalType.data(), index)
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(child),
-	}
+	return trackedLogicalType(child)
 }
 
 func UnionTypeMemberCount(logicalType LogicalType) IdxT {
@@ -263,12 +198,7 @@ func UnionTypeMemberName(logicalType LogicalType, index IdxT) string {
 // The return value must be destroyed with DestroyLogicalType.
 func UnionTypeMemberType(logicalType LogicalType, index IdxT) LogicalType {
 	t := C.duckdb_union_type_member_type(logicalType.data(), index)
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(t),
-	}
+	return trackedLogicalType(t)
 }
 
 func GeometryTypeGetCRS(logicalType LogicalType) string {
@@ -285,9 +215,7 @@ func DestroyLogicalType(logicalType *LogicalType) {
 	if logicalType.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("logicalType")
-	}
+	releaseAllocation(logicalTypeAllocation, logicalType.Ptr)
 	data := logicalType.data()
 	C.duckdb_destroy_logical_type(&data)
 	logicalType.Ptr = nil

--- a/prepared.go
+++ b/prepared.go
@@ -18,10 +18,7 @@ func Prepare(conn Connection, query string, outPreparedStmt *PreparedStatement) 
 
 	var preparedStmt C.duckdb_prepared_statement
 	state := C.duckdb_prepare(conn.data(), cQuery, &preparedStmt)
-	outPreparedStmt.Ptr = unsafe.Pointer(preparedStmt)
-	if debugMode {
-		incrAllocCount("preparedStmt")
-	}
+	*outPreparedStmt = trackedPreparedStatement(preparedStmt)
 	return state
 }
 
@@ -30,9 +27,7 @@ func DestroyPrepare(preparedStmt *PreparedStatement) {
 	if preparedStmt.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("preparedStmt")
-	}
+	releaseAllocation(preparedStatementAllocation, preparedStmt.Ptr)
 	data := preparedStmt.data()
 	C.duckdb_destroy_prepare(&data)
 	preparedStmt.Ptr = nil
@@ -61,12 +56,7 @@ func ParamType(preparedStmt PreparedStatement, index IdxT) Type {
 // The return value must be destroyed with DestroyLogicalType.
 func ParamLogicalType(preparedStmt PreparedStatement, index IdxT) LogicalType {
 	logicalType := C.duckdb_param_logical_type(preparedStmt.data(), index)
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(logicalType),
-	}
+	return trackedLogicalType(logicalType)
 }
 
 func ClearBindings(preparedStmt PreparedStatement) State {
@@ -91,12 +81,7 @@ func PreparedStatementColumnName(preparedStmt PreparedStatement, index IdxT) str
 // The return value must be destroyed with DestroyLogicalType.
 func PreparedStatementColumnLogicalType(preparedStmt PreparedStatement, index IdxT) LogicalType {
 	logicalType := C.duckdb_prepared_statement_column_logical_type(preparedStmt.data(), index)
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(logicalType),
-	}
+	return trackedLogicalType(logicalType)
 }
 
 func PreparedStatementColumnType(preparedStmt PreparedStatement, index IdxT) Type {
@@ -216,20 +201,18 @@ func BindNull(preparedStmt PreparedStatement, index IdxT) State {
 // ExecutePrepared wraps duckdb_execute_prepared.
 // outRes must be destroyed with DestroyResult.
 func ExecutePrepared(preparedStmt PreparedStatement, outRes *Result) State {
-	if debugMode {
-		incrAllocCount("res")
-	}
-	return C.duckdb_execute_prepared(preparedStmt.data(), &outRes.data)
+	state := C.duckdb_execute_prepared(preparedStmt.data(), &outRes.data)
+	trackedResult(outRes)
+	return state
 }
 
 // ExecutePreparedStreaming wraps duckdb_execute_prepared_streaming.
 // outRes must be destroyed with DestroyResult.
 // Deprecated: ExecutePreparedStreaming is deprecated.
 func ExecutePreparedStreaming(preparedStmt PreparedStatement, outRes *Result) State {
-	if debugMode {
-		incrAllocCount("res")
-	}
-	return C.duckdb_execute_prepared_streaming(preparedStmt.data(), &outRes.data)
+	state := C.duckdb_execute_prepared_streaming(preparedStmt.data(), &outRes.data)
+	trackedResult(outRes)
+	return state
 }
 
 // ExtractStatements wraps duckdb_extract_statements.
@@ -240,10 +223,7 @@ func ExtractStatements(conn Connection, query string, outExtractedStmts *Extract
 
 	var extractedStmts C.duckdb_extracted_statements
 	count := C.duckdb_extract_statements(conn.data(), cQuery, &extractedStmts)
-	outExtractedStmts.Ptr = unsafe.Pointer(extractedStmts)
-	if debugMode {
-		incrAllocCount("extractedStmts")
-	}
+	*outExtractedStmts = trackedExtractedStatements(extractedStmts)
 	return count
 }
 
@@ -252,10 +232,7 @@ func ExtractStatements(conn Connection, query string, outExtractedStmts *Extract
 func PrepareExtractedStatement(conn Connection, extractedStmts ExtractedStatements, index IdxT, outPreparedStmt *PreparedStatement) State {
 	var preparedStmt C.duckdb_prepared_statement
 	state := C.duckdb_prepare_extracted_statement(conn.data(), extractedStmts.data(), index, &preparedStmt)
-	outPreparedStmt.Ptr = unsafe.Pointer(preparedStmt)
-	if debugMode {
-		incrAllocCount("preparedStmt")
-	}
+	*outPreparedStmt = trackedPreparedStatement(preparedStmt)
 	return state
 }
 
@@ -269,9 +246,7 @@ func DestroyExtracted(extractedStmts *ExtractedStatements) {
 	if extractedStmts.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("extractedStmts")
-	}
+	releaseAllocation(extractedStatementsAllocation, extractedStmts.Ptr)
 	data := extractedStmts.data()
 	C.duckdb_destroy_extracted(&data)
 	extractedStmts.Ptr = nil
@@ -282,10 +257,7 @@ func DestroyExtracted(extractedStmts *ExtractedStatements) {
 func PendingPrepared(preparedStmt PreparedStatement, outPendingRes *PendingResult) State {
 	var pendingRes C.duckdb_pending_result
 	state := C.duckdb_pending_prepared(preparedStmt.data(), &pendingRes)
-	outPendingRes.Ptr = unsafe.Pointer(pendingRes)
-	if debugMode {
-		incrAllocCount("pendingRes")
-	}
+	*outPendingRes = trackedPendingResult(pendingRes)
 	return state
 }
 
@@ -295,10 +267,7 @@ func PendingPrepared(preparedStmt PreparedStatement, outPendingRes *PendingResul
 func PendingPreparedStreaming(preparedStmt PreparedStatement, outPendingRes *PendingResult) State {
 	var pendingRes C.duckdb_pending_result
 	state := C.duckdb_pending_prepared_streaming(preparedStmt.data(), &pendingRes)
-	outPendingRes.Ptr = unsafe.Pointer(pendingRes)
-	if debugMode {
-		incrAllocCount("pendingRes")
-	}
+	*outPendingRes = trackedPendingResult(pendingRes)
 	return state
 }
 
@@ -307,9 +276,7 @@ func DestroyPending(pendingRes *PendingResult) {
 	if pendingRes.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("pendingRes")
-	}
+	releaseAllocation(pendingResultAllocation, pendingRes.Ptr)
 	data := pendingRes.data()
 	C.duckdb_destroy_pending(&data)
 	pendingRes.Ptr = nil
@@ -331,10 +298,9 @@ func PendingExecuteCheckState(pendingRes PendingResult) PendingState {
 // ExecutePending wraps duckdb_execute_pending.
 // outRes must be destroyed with DestroyResult.
 func ExecutePending(res PendingResult, outRes *Result) State {
-	if debugMode {
-		incrAllocCount("res")
-	}
-	return C.duckdb_execute_pending(res.data(), &outRes.data)
+	state := C.duckdb_execute_pending(res.data(), &outRes.data)
+	trackedResult(outRes)
+	return state
 }
 
 func PendingExecutionIsFinished(state PendingState) bool {

--- a/profiling.go
+++ b/profiling.go
@@ -24,24 +24,14 @@ func ProfilingInfoGetValue(info ProfilingInfo, key string) Value {
 	defer Free(unsafe.Pointer(cKey))
 	v := C.duckdb_profiling_info_get_value(info.data(), cKey)
 
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // ProfilingInfoGetMetrics wraps duckdb_profiling_info_get_metrics.
 // The return value must be destroyed with DestroyValue.
 func ProfilingInfoGetMetrics(info ProfilingInfo) Value {
 	v := C.duckdb_profiling_info_get_metrics(info.data())
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 func ProfilingInfoGetChildCount(info ProfilingInfo) IdxT {

--- a/query.go
+++ b/query.go
@@ -13,13 +13,12 @@ import "unsafe"
 // Query wraps duckdb_query.
 // outRes must be destroyed with DestroyResult.
 func Query(conn Connection, query string, outRes *Result) State {
-	if debugMode {
-		incrAllocCount("res")
-	}
 	cQuery := C.CString(query)
 	defer Free(unsafe.Pointer(cQuery))
 
-	return C.duckdb_query(conn.data(), cQuery, &outRes.data)
+	state := C.duckdb_query(conn.data(), cQuery, &outRes.data)
+	trackedResult(outRes)
+	return state
 }
 
 // DestroyResult wraps duckdb_destroy_result.
@@ -27,9 +26,7 @@ func DestroyResult(res *Result) {
 	if res == nil || res.data.internal_data == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("res")
-	}
+	releaseAllocation(resultAllocation, res.data.internal_data)
 	C.duckdb_destroy_result(&res.data)
 	res.data.internal_data = nil
 }
@@ -51,24 +48,14 @@ func ResultStatementType(res Result) StatementType {
 // The return value must be destroyed with DestroyLogicalType.
 func ColumnLogicalType(res *Result, col IdxT) LogicalType {
 	logicalType := C.duckdb_column_logical_type(&res.data, col)
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(logicalType),
-	}
+	return trackedLogicalType(logicalType)
 }
 
 // ResultGetArrowOptions wraps duckdb_result_get_arrow_options.
 // The return value must be destroyed with DestroyArrowOptions.
 func ResultGetArrowOptions(res *Result) ArrowOptions {
 	options := C.duckdb_result_get_arrow_options(&res.data)
-	if debugMode {
-		incrAllocCount("arrowOptions")
-	}
-	return ArrowOptions{
-		Ptr: unsafe.Pointer(options),
-	}
+	return trackedArrowOptions(options)
 }
 
 func ColumnCount(res *Result) IdxT {
@@ -93,12 +80,7 @@ func ResultErrorType(res *Result) ErrorType {
 // Deprecated: See C API documentation.
 func ResultGetChunk(res Result, index IdxT) DataChunk {
 	chunk := C.duckdb_result_get_chunk(res.data, index)
-	if debugMode {
-		incrAllocCount("chunk")
-	}
-	return DataChunk{
-		Ptr: unsafe.Pointer(chunk),
-	}
+	return trackedDataChunk(chunk)
 }
 
 // ResultIsStreaming wraps duckdb_result_is_streaming.
@@ -127,21 +109,13 @@ func StreamFetchChunk(res Result, outChunk *DataChunk) State {
 	if chunk == nil {
 		return StateError
 	}
-	outChunk.Ptr = unsafe.Pointer(chunk)
-	if debugMode {
-		incrAllocCount("chunk")
-	}
+	*outChunk = trackedDataChunk(chunk)
 	return StateSuccess
 }
 
 func FetchChunk(res Result) DataChunk {
 	chunk := C.duckdb_fetch_chunk(res.data)
-	if debugMode && chunk != nil {
-		incrAllocCount("chunk")
-	}
-	return DataChunk{
-		Ptr: unsafe.Pointer(chunk),
-	}
+	return trackedDataChunk(chunk)
 }
 
 // Deprecated: See C API documentation.

--- a/query.go
+++ b/query.go
@@ -99,9 +99,10 @@ func ResultReturnType(res Result) ResultType {
 }
 
 // StreamFetchChunk wraps duckdb_stream_fetch_chunk.
-// Returns a data chunk from the streaming result.
-// The returned data chunk must be destroyed with DestroyDataChunk.
-// Returns a data chunk with size 0 when the result is exhausted.
+// Returns StateSuccess with a data chunk from the streaming result.
+// A StateSuccess chunk with size 0 indicates that the result is exhausted.
+// A StateError return indicates that DuckDB returned NULL for an error.
+// The returned data chunk must be destroyed with DestroyDataChunk after StateSuccess.
 // Deprecated: StreamFetchChunk is deprecated.
 func StreamFetchChunk(res Result, outChunk *DataChunk) State {
 	chunk := C.duckdb_stream_fetch_chunk(res.data)

--- a/scalar_function.go
+++ b/scalar_function.go
@@ -14,12 +14,7 @@ import "unsafe"
 // The return value must be destroyed with DestroyScalarFunction.
 func CreateScalarFunction() ScalarFunction {
 	f := C.duckdb_create_scalar_function()
-	if debugMode {
-		incrAllocCount("scalarFunc")
-	}
-	return ScalarFunction{
-		Ptr: unsafe.Pointer(f),
-	}
+	return trackedScalarFunction(f)
 }
 
 // DestroyScalarFunction wraps duckdb_destroy_scalar_function.
@@ -27,9 +22,7 @@ func DestroyScalarFunction(f *ScalarFunction) {
 	if f.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("scalarFunc")
-	}
+	releaseAllocation(scalarFunctionAllocation, f.Ptr)
 	data := f.data()
 	C.duckdb_destroy_scalar_function(&data)
 	f.Ptr = nil
@@ -113,10 +106,7 @@ func ScalarFunctionGetBindData(info FunctionInfo) unsafe.Pointer {
 func ScalarFunctionGetClientContext(info BindInfo, outCtx *ClientContext) {
 	var ctx C.duckdb_client_context
 	C.duckdb_scalar_function_get_client_context(info.data(), &ctx)
-	outCtx.Ptr = unsafe.Pointer(ctx)
-	if debugMode {
-		incrAllocCount("ctx")
-	}
+	*outCtx = trackedClientContext(ctx)
 }
 
 func ScalarFunctionSetError(info FunctionInfo, err string) {
@@ -132,12 +122,7 @@ func CreateScalarFunctionSet(name string) ScalarFunctionSet {
 	defer Free(unsafe.Pointer(cName))
 
 	set := C.duckdb_create_scalar_function_set(cName)
-	if debugMode {
-		incrAllocCount("scalarFuncSet")
-	}
-	return ScalarFunctionSet{
-		Ptr: unsafe.Pointer(set),
-	}
+	return trackedScalarFunctionSet(set)
 }
 
 // DestroyScalarFunctionSet wraps duckdb_destroy_scalar_function_set.
@@ -145,9 +130,7 @@ func DestroyScalarFunctionSet(set *ScalarFunctionSet) {
 	if set.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("scalarFuncSet")
-	}
+	releaseAllocation(scalarFunctionSetAllocation, set.Ptr)
 	data := set.data()
 	C.duckdb_destroy_scalar_function_set(&data)
 	set.Ptr = nil
@@ -169,10 +152,5 @@ func ScalarFunctionBindGetArgumentCount(info BindInfo) IdxT {
 // The return value must be destroyed with DestroyExpression.
 func ScalarFunctionBindGetArgument(info BindInfo, index IdxT) Expression {
 	expr := C.duckdb_scalar_function_bind_get_argument(info.data(), index)
-	if debugMode {
-		incrAllocCount("expr")
-	}
-	return Expression{
-		Ptr: unsafe.Pointer(expr),
-	}
+	return trackedExpression(expr)
 }

--- a/selection_vector.go
+++ b/selection_vector.go
@@ -8,18 +8,11 @@ package duckdb_go_bindings
 */
 import "C"
 
-import "unsafe"
-
 // CreateSelectionVector wraps duckdb_create_selection_vector.
 // The return value must be destroyed with DestroySelectionVector.
 func CreateSelectionVector(size IdxT) SelectionVector {
 	sel := C.duckdb_create_selection_vector(size)
-	if debugMode {
-		incrAllocCount("sel")
-	}
-	return SelectionVector{
-		Ptr: unsafe.Pointer(sel),
-	}
+	return trackedSelectionVector(sel)
 }
 
 // DestroySelectionVector wraps duckdb_destroy_selection_vector.
@@ -27,9 +20,7 @@ func DestroySelectionVector(sel *SelectionVector) {
 	if sel.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("sel")
-	}
+	releaseAllocation(selectionVectorAllocation, sel.Ptr)
 	C.duckdb_destroy_selection_vector(sel.data())
 	sel.Ptr = nil
 }

--- a/table_description.go
+++ b/table_description.go
@@ -20,10 +20,7 @@ func TableDescriptionCreate(conn Connection, schema string, table string, outDes
 
 	var description C.duckdb_table_description
 	state := C.duckdb_table_description_create(conn.data(), cSchema, cTable, &description)
-	outDesc.Ptr = unsafe.Pointer(description)
-	if debugMode {
-		incrAllocCount("tableDesc")
-	}
+	*outDesc = trackedTableDescription(description)
 	return state
 }
 
@@ -39,10 +36,7 @@ func TableDescriptionCreateExt(conn Connection, catalog string, schema string, t
 
 	var description C.duckdb_table_description
 	state := C.duckdb_table_description_create_ext(conn.data(), cCatalog, cSchema, cTable, &description)
-	outDesc.Ptr = unsafe.Pointer(description)
-	if debugMode {
-		incrAllocCount("tableDesc")
-	}
+	*outDesc = trackedTableDescription(description)
 	return state
 }
 
@@ -51,9 +45,7 @@ func TableDescriptionDestroy(desc *TableDescription) {
 	if desc.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("tableDesc")
-	}
+	releaseAllocation(tableDescriptionAllocation, desc.Ptr)
 	data := desc.data()
 	C.duckdb_table_description_destroy(&data)
 	desc.Ptr = nil
@@ -85,10 +77,5 @@ func TableDescriptionGetColumnName(desc TableDescription, index IdxT) string {
 // The return value must be destroyed with DestroyLogicalType.
 func TableDescriptionGetColumnType(desc TableDescription, index IdxT) LogicalType {
 	logicalType := C.duckdb_table_description_get_column_type(desc.data(), index)
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(logicalType),
-	}
+	return trackedLogicalType(logicalType)
 }

--- a/table_function.go
+++ b/table_function.go
@@ -14,12 +14,7 @@ import "unsafe"
 // The return value must be destroyed with DestroyTableFunction.
 func CreateTableFunction() TableFunction {
 	f := C.duckdb_create_table_function()
-	if debugMode {
-		incrAllocCount("tableFunc")
-	}
-	return TableFunction{
-		Ptr: unsafe.Pointer(f),
-	}
+	return trackedTableFunction(f)
 }
 
 // DestroyTableFunction wraps duckdb_destroy_table_function.
@@ -27,9 +22,7 @@ func DestroyTableFunction(f *TableFunction) {
 	if f.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("tableFunc")
-	}
+	releaseAllocation(tableFunctionAllocation, f.Ptr)
 	data := f.data()
 	C.duckdb_destroy_table_function(&data)
 	f.Ptr = nil
@@ -93,10 +86,7 @@ func BindGetExtraInfo(info BindInfo) unsafe.Pointer {
 func TableFunctionGetClientContext(info BindInfo, outCtx *ClientContext) {
 	var ctx C.duckdb_client_context
 	C.duckdb_table_function_get_client_context(info.data(), &ctx)
-	outCtx.Ptr = unsafe.Pointer(ctx)
-	if debugMode {
-		incrAllocCount("ctx")
-	}
+	*outCtx = trackedClientContext(ctx)
 }
 
 func BindAddResultColumn(info BindInfo, name string, logicalType LogicalType) {
@@ -113,12 +103,7 @@ func BindGetParameterCount(info BindInfo) IdxT {
 // The return value must be destroyed with DestroyValue.
 func BindGetParameter(info BindInfo, index IdxT) Value {
 	v := C.duckdb_bind_get_parameter(info.data(), index)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // BindGetNamedParameter wraps duckdb_bind_get_named_parameter.
@@ -127,12 +112,7 @@ func BindGetNamedParameter(info BindInfo, name string) Value {
 	cName := C.CString(name)
 	defer Free(unsafe.Pointer(cName))
 	v := C.duckdb_bind_get_named_parameter(info.data(), cName)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 func BindSetBindData(info BindInfo, bindDataPtr unsafe.Pointer, callbackPtr unsafe.Pointer) {

--- a/types.go
+++ b/types.go
@@ -294,15 +294,12 @@ func ListEntryMembers(entry *ListEntry) (uint64, uint64) {
 // The data is stored in little endian format (absolute value).
 // The returned BigNum must be destroyed with DestroyBigNum.
 func NewBigNum(data []byte, isNegative bool) BigNum {
-	if debugMode {
-		incrAllocCount("bigNum")
-	}
 	cData := (*C.uint8_t)(C.CBytes(data))
-	return BigNum{
+	return trackedBigNum(BigNum{
 		data:        cData,
 		size:        C.idx_t(len(data)),
 		is_negative: C.bool(isNegative),
-	}
+	})
 }
 
 // BigNumMembers returns the data bytes and sign of a BigNum.
@@ -318,14 +315,11 @@ func BigNumMembers(bn *BigNum) ([]byte, bool) {
 // The first byte contains the number of padding bits.
 // The padding bits of the second byte are set to 1, starting from the MSB.
 func NewBit(data []byte) Bit {
-	if debugMode {
-		incrAllocCount("bit")
-	}
 	cData := (*C.uint8_t)(C.CBytes(data))
-	return Bit{
+	return trackedBit(Bit{
 		data: cData,
 		size: C.idx_t(len(data)),
-	}
+	})
 }
 
 // BitMembers returns the data bytes of a Bit.
@@ -340,35 +334,32 @@ func BitMembers(b *Bit) []byte {
 
 // DestroyBlob destroys the data field of duckdb_blob.
 func DestroyBlob(b *Blob) {
-	if b == nil {
+	if b == nil || b.data == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("blob")
-	}
+	releaseAllocation(blobAllocation, b.data)
 	Free(b.data)
+	b.data = nil
 }
 
 // DestroyBit destroys the data field of duckdb_bit.
 func DestroyBit(b *Bit) {
-	if b == nil {
+	if b == nil || b.data == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("bit")
-	}
+	releaseAllocation(bitAllocation, unsafe.Pointer(b.data))
 	Free(unsafe.Pointer(b.data))
+	b.data = nil
 }
 
 // DestroyBigNum destroys the data field of duckdb_bignum.
 func DestroyBigNum(i *BigNum) {
-	if i == nil {
+	if i == nil || i.data == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("bigNum")
-	}
+	releaseAllocation(bigNumAllocation, unsafe.Pointer(i.data))
 	Free(unsafe.Pointer(i.data))
+	i.data = nil
 }
 
 func FromDate(date Date) DateStruct {

--- a/value.go
+++ b/value.go
@@ -15,9 +15,7 @@ func DestroyValue(v *Value) {
 	if v.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("v")
-	}
+	releaseAllocation(valueAllocation, v.Ptr)
 	data := v.data()
 	C.duckdb_destroy_value(&data)
 	v.Ptr = nil
@@ -37,12 +35,7 @@ func CreateVarcharLength(str string, length IdxT) Value {
 		cStr = (*C.char)(unsafe.Pointer(unsafe.StringData(str)))
 	}
 	v := C.duckdb_create_varchar_length(cStr, length)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 func ValidUtf8Check(blob []byte) ErrorData {
@@ -51,312 +44,182 @@ func ValidUtf8Check(blob []byte) ErrorData {
 		blobPtr = (*C.char)(unsafe.Pointer(&blob[0]))
 	}
 	errorData := C.duckdb_valid_utf8_check(blobPtr, IdxT(len(blob)))
-	if debugMode {
-		incrAllocCount("errorData")
-	}
-	return ErrorData{
-		Ptr: unsafe.Pointer(errorData),
-	}
+	return trackedErrorData(errorData)
 }
 
 // CreateBool wraps duckdb_create_bool.
 // The return value must be destroyed with DestroyValue.
 func CreateBool(val bool) Value {
 	v := C.duckdb_create_bool(C.bool(val))
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateInt8 wraps duckdb_create_int8.
 // The return value must be destroyed with DestroyValue.
 func CreateInt8(val int8) Value {
 	v := C.duckdb_create_int8(C.int8_t(val))
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateUInt8 wraps duckdb_create_uint8.
 // The return value must be destroyed with DestroyValue.
 func CreateUInt8(val uint8) Value {
 	v := C.duckdb_create_uint8(C.uint8_t(val))
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateInt16 wraps duckdb_create_int16.
 // The return value must be destroyed with DestroyValue.
 func CreateInt16(val int16) Value {
 	v := C.duckdb_create_int16(C.int16_t(val))
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateUInt16 wraps duckdb_create_uint16.
 // The return value must be destroyed with DestroyValue.
 func CreateUInt16(val uint16) Value {
 	v := C.duckdb_create_uint16(C.uint16_t(val))
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateInt32 wraps duckdb_create_int32.
 // The return value must be destroyed with DestroyValue.
 func CreateInt32(val int32) Value {
 	v := C.duckdb_create_int32(C.int32_t(val))
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateUInt32 wraps duckdb_create_uint32.
 // The return value must be destroyed with DestroyValue.
 func CreateUInt32(val uint32) Value {
 	v := C.duckdb_create_uint32(C.uint32_t(val))
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateUInt64 wraps duckdb_create_uint64.
 // The return value must be destroyed with DestroyValue.
 func CreateUInt64(val uint64) Value {
 	v := C.duckdb_create_uint64(C.uint64_t(val))
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateInt64 wraps duckdb_create_int64.
 // The return value must be destroyed with DestroyValue.
 func CreateInt64(val int64) Value {
 	v := C.duckdb_create_int64(C.int64_t(val))
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateHugeInt wraps duckdb_create_hugeint.
 // The return value must be destroyed with DestroyValue.
 func CreateHugeInt(val HugeInt) Value {
 	v := C.duckdb_create_hugeint(val)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateUHugeInt wraps duckdb_create_uhugeint.
 // The return value must be destroyed with DestroyValue.
 func CreateUHugeInt(val UHugeInt) Value {
 	v := C.duckdb_create_uhugeint(val)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateBigNum wraps duckdb_create_bignum.
 // The return value must be destroyed with DestroyValue.
 func CreateBigNum(val BigNum) Value {
 	v := C.duckdb_create_bignum(val)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateDecimal wraps duckdb_create_decimal.
 // The return value must be destroyed with DestroyValue.
 func CreateDecimal(val Decimal) Value {
 	v := C.duckdb_create_decimal(val)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateFloat wraps duckdb_create_float.
 // The return value must be destroyed with DestroyValue.
 func CreateFloat(val float32) Value {
 	v := C.duckdb_create_float(C.float(val))
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateDouble wraps duckdb_create_double.
 // The return value must be destroyed with DestroyValue.
 func CreateDouble(val float64) Value {
 	v := C.duckdb_create_double(C.double(val))
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateDate wraps duckdb_create_date.
 // The return value must be destroyed with DestroyValue.
 func CreateDate(val Date) Value {
 	v := C.duckdb_create_date(val)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateTime wraps duckdb_create_time.
 // The return value must be destroyed with DestroyValue.
 func CreateTime(val Time) Value {
 	v := C.duckdb_create_time(val)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateTimeNS wraps duckdb_create_time_ns.
 // The return value must be destroyed with DestroyValue.
 func CreateTimeNS(val TimeNS) Value {
 	v := C.duckdb_create_time_ns(val)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateTimeTZValue wraps duckdb_create_time_tz_value.
 // The return value must be destroyed with DestroyValue.
 func CreateTimeTZValue(timeTZ TimeTZ) Value {
 	v := C.duckdb_create_time_tz_value(timeTZ)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateTimestamp wraps duckdb_create_timestamp.
 // The return value must be destroyed with DestroyValue.
 func CreateTimestamp(val Timestamp) Value {
 	v := C.duckdb_create_timestamp(val)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateTimestampTZ wraps duckdb_create_timestamp_tz.
 // The return value must be destroyed with DestroyValue.
 func CreateTimestampTZ(val Timestamp) Value {
 	v := C.duckdb_create_timestamp_tz(val)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateTimestampS wraps duckdb_create_timestamp_s.
 // The return value must be destroyed with DestroyValue.
 func CreateTimestampS(val TimestampS) Value {
 	v := C.duckdb_create_timestamp_s(val)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateTimestampMS wraps duckdb_create_timestamp_ms.
 // The return value must be destroyed with DestroyValue.
 func CreateTimestampMS(val TimestampMS) Value {
 	v := C.duckdb_create_timestamp_ms(val)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateTimestampNS wraps duckdb_create_timestamp_ns.
 // The return value must be destroyed with DestroyValue.
 func CreateTimestampNS(val TimestampNS) Value {
 	v := C.duckdb_create_timestamp_ns(val)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateInterval wraps duckdb_create_interval.
 // The return value must be destroyed with DestroyValue.
 func CreateInterval(val Interval) Value {
 	v := C.duckdb_create_interval(val)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateBlob wraps duckdb_create_blob.
@@ -368,36 +231,21 @@ func CreateBlob(val []byte) Value {
 	}
 
 	v := C.duckdb_create_blob(data, IdxT(len(val)))
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateBit wraps duckdb_create_bit.
 // The return value must be destroyed with DestroyValue.
 func CreateBit(val Bit) Value {
 	v := C.duckdb_create_bit(val)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateUUID wraps duckdb_create_uuid.
 // The return value must be destroyed with DestroyValue.
 func CreateUUID(val UHugeInt) Value {
 	v := C.duckdb_create_uuid(val)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 func GetBool(v Value) bool {
@@ -456,10 +304,8 @@ func GetUHugeInt(v Value) UHugeInt {
 // GetBigNum wraps duckdb_get_bignum.
 // The return value must be destroyed with DestroyBigNum.
 func GetBigNum(v Value) BigNum {
-	if debugMode {
-		incrAllocCount("bigNum")
-	}
-	return C.duckdb_get_bignum(v.data())
+	bigNum := C.duckdb_get_bignum(v.data())
+	return trackedBigNum(bigNum)
 }
 
 func GetDecimal(v Value) Decimal {
@@ -528,19 +374,15 @@ func GetValueType(v Value) LogicalType {
 // GetBlob wraps duckdb_get_blob.
 // The return value must be destroyed with DestroyBlob.
 func GetBlob(v Value) Blob {
-	if debugMode {
-		incrAllocCount("blob")
-	}
-	return C.duckdb_get_blob(v.data())
+	blob := C.duckdb_get_blob(v.data())
+	return trackedBlob(blob)
 }
 
 // GetBit wraps duckdb_get_bit.
 // The return value must be destroyed with DestroyBit.
 func GetBit(v Value) Bit {
-	if debugMode {
-		incrAllocCount("bit")
-	}
-	return C.duckdb_get_bit(v.data())
+	bit := C.duckdb_get_bit(v.data())
+	return trackedBit(bit)
 }
 
 func GetUUID(v Value) UHugeInt {
@@ -560,14 +402,7 @@ func CreateStructValue(logicalType LogicalType, values []Value) Value {
 	defer Free(unsafe.Pointer(valuesPtr))
 
 	v := C.duckdb_create_struct_value(logicalType.data(), valuesPtr)
-
-	if debugMode {
-		incrAllocCount("v")
-	}
-
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateListValue wraps duckdb_create_list_value.
@@ -577,14 +412,7 @@ func CreateListValue(logicalType LogicalType, values []Value) Value {
 	defer Free(unsafe.Pointer(valuesPtr))
 
 	v := C.duckdb_create_list_value(logicalType.data(), valuesPtr, IdxT(len(values)))
-
-	if debugMode {
-		incrAllocCount("v")
-	}
-
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateArrayValue wraps duckdb_create_array_value.
@@ -594,14 +422,7 @@ func CreateArrayValue(logicalType LogicalType, values []Value) Value {
 	defer Free(unsafe.Pointer(valuesPtr))
 
 	v := C.duckdb_create_array_value(logicalType.data(), valuesPtr, IdxT(len(values)))
-
-	if debugMode {
-		incrAllocCount("v")
-	}
-
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateMapValue wraps duckdb_create_map_value.
@@ -614,26 +435,14 @@ func CreateMapValue(logicalType LogicalType, keys []Value, values []Value) Value
 	defer Free(unsafe.Pointer(valueValuesPtr))
 
 	m := C.duckdb_create_map_value(logicalType.data(), keyValuesPtr, valueValuesPtr, IdxT(len(keys)))
-
-	if debugMode {
-		incrAllocCount("v")
-	}
-
-	return Value{
-		Ptr: unsafe.Pointer(m),
-	}
+	return trackedValue(m)
 }
 
 // CreateUnionValue wraps duckdb_create_union_value.
 // The return value must be destroyed with DestroyValue.
 func CreateUnionValue(logicalType LogicalType, tag IdxT, value Value) Value {
 	v := C.duckdb_create_union_value(logicalType.data(), tag, value.data())
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 func GetMapSize(v Value) IdxT {
@@ -644,24 +453,14 @@ func GetMapSize(v Value) IdxT {
 // The return value must be destroyed with DestroyValue.
 func GetMapKey(v Value, index IdxT) Value {
 	value := C.duckdb_get_map_key(v.data(), index)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(value),
-	}
+	return trackedValue(value)
 }
 
 // GetMapValue wraps duckdb_get_map_value.
 // The return value must be destroyed with DestroyValue.
 func GetMapValue(v Value, index IdxT) Value {
 	value := C.duckdb_get_map_value(v.data(), index)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(value),
-	}
+	return trackedValue(value)
 }
 
 func IsNullValue(v Value) bool {
@@ -672,12 +471,7 @@ func IsNullValue(v Value) bool {
 // The return value must be destroyed with DestroyValue.
 func CreateNullValue() Value {
 	v := C.duckdb_create_null_value()
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 func GetListSize(v Value) IdxT {
@@ -688,24 +482,14 @@ func GetListSize(v Value) IdxT {
 // The return value must be destroyed with DestroyValue.
 func GetListChild(val Value, index IdxT) Value {
 	v := C.duckdb_get_list_child(val.data(), index)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 // CreateEnumValue wraps duckdb_create_enum_value.
 // The return value must be destroyed with DestroyValue.
 func CreateEnumValue(logicalType LogicalType, val uint64) Value {
 	v := C.duckdb_create_enum_value(logicalType.data(), C.uint64_t(val))
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 func GetEnumValue(v Value) uint64 {
@@ -716,12 +500,7 @@ func GetEnumValue(v Value) uint64 {
 // The return value must be destroyed with DestroyValue.
 func GetStructChild(val Value, index IdxT) Value {
 	v := C.duckdb_get_struct_child(val.data(), index)
-	if debugMode {
-		incrAllocCount("v")
-	}
-	return Value{
-		Ptr: unsafe.Pointer(v),
-	}
+	return trackedValue(v)
 }
 
 func ValueToString(val Value) string {

--- a/vector.go
+++ b/vector.go
@@ -18,12 +18,7 @@ func VectorSize() IdxT {
 // The return value must be destroyed with DestroyVector.
 func CreateVector(logicalType LogicalType, capacity IdxT) Vector {
 	vec := C.duckdb_create_vector(logicalType.data(), capacity)
-	if debugMode {
-		incrAllocCount("vec")
-	}
-	return Vector{
-		Ptr: unsafe.Pointer(vec),
-	}
+	return trackedVector(vec)
 }
 
 // DestroyVector wraps duckdb_destroy_vector.
@@ -31,9 +26,7 @@ func DestroyVector(vec *Vector) {
 	if vec.Ptr == nil {
 		return
 	}
-	if debugMode {
-		decrAllocCount("vec")
-	}
+	releaseAllocation(vectorAllocation, vec.Ptr)
 	data := vec.data()
 	C.duckdb_destroy_vector(&data)
 	vec.Ptr = nil
@@ -43,12 +36,7 @@ func DestroyVector(vec *Vector) {
 // The return value must be destroyed with DestroyLogicalType.
 func VectorGetColumnType(vec Vector) LogicalType {
 	logicalType := C.duckdb_vector_get_column_type(vec.data())
-	if debugMode {
-		incrAllocCount("logicalType")
-	}
-	return LogicalType{
-		Ptr: unsafe.Pointer(logicalType),
-	}
+	return trackedLogicalType(logicalType)
 }
 
 func VectorGetData(vec Vector) unsafe.Pointer {


### PR DESCRIPTION
This centralizes allocation accounting so each resource type has one canonical counter identity instead of relying on hand-typed string keys across wrapper call sites. It also makes debug leak checks more trustworthy by counting only confirmed non-nil allocations after C calls return, so failed/null paths no longer create false counter balances. The result is lifecycle accounting that is tied to wrapper construction and destruction rather than a parallel convention that can drift silently.